### PR TITLE
Fix: remove dependency on openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "4.5", features = ["derive"] }
 crc32fast = "1.3"
 futures = "0.3"
 indicatif = "0.17"
-reqwest = {version = "0.12.14", features = ["json", "stream"] }
+reqwest = {version = "0.12.14", features = ["json", "stream", "rustls-tls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0" 
 shellexpand = "3.1"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://github.com/endoze/valheim-mod-manager/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/endoze/valheim-mod-manager/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/endoze/valheim-mod-manager/badge.svg?branch=master)](https://coveralls.io/github/endoze/valheim-mod-manager?branch=master)
 [![Crate](https://img.shields.io/crates/v/valheim-mod-manager.svg)](https://crates.io/crates/valheim-mod-manager)
-[![Docs](https://docs.rs/valheim-mod-manager/badge.svg)](https://docs.rs/valheim-mod-manager)
 
 A command-line tool for managing and automatically downloading Valheim mods and their dependencies.
 


### PR DESCRIPTION
In order to ensure this project builds on linux musl x86_64, this commit swaps the tls implementation of reqwest to use rustls-tls instead of the default of relying on openssl. This ensures we can build on linux musl as openssl is not available by default.

Additionally, it removes the link to docs.rs as this crate currently does not have a library component.