### PR TITLE
chore: migrate to Windows Server 2022 for release builds

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,3 +22,4 @@ allow-dirty = ["ci", "msi"]
 [dist.github-custom-runners]
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
 x86_64-unknown-linux-musl = "ubuntu-22.04"
+x86_64-pc-windows-msvc = "windows-2022"


### PR DESCRIPTION
GitHub has deprecated the Windows Server 2019 runner platform, which
was previously used as the default for Windows builds. To ensure
continued support for Windows release artifacts, we need to explicitly
configure the build to use Windows Server 2022, the current supported
platform for Windows-based GitHub Actions runners.
