### PR TITLE
Implement string interning for package manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +39,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -895,6 +913,11 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "serde",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1285,6 +1308,16 @@ checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
 dependencies = [
  "pest",
  "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "lasso"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
+dependencies = [
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -2679,6 +2712,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "indicatif",
+ "lasso",
  "mockito",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ zip = "2.2.3"
 bincode = "1.3.3"
 zstd = "0.13.0"
 fs_extra = "1.3.0"
+lasso = { version = "0.7", features = ["serialize"] }
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/benches/manifest_formats.rs
+++ b/benches/manifest_formats.rs
@@ -1,7 +1,9 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use std::fs;
 use std::path::PathBuf;
-use valheim_mod_manager::package::{Package, PackageManifest};
+use valheim_mod_manager::package::{
+  InternedPackageManifest, Package, PackageManifest, SerializableInternedManifest,
+};
 
 fn load_real_manifest_v1() -> Option<Vec<Package>> {
   let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -18,6 +20,7 @@ fn load_real_manifest_v1() -> Option<Vec<Package>> {
   bincode::deserialize(&decompressed_data).ok()
 }
 
+#[allow(dead_code)]
 fn load_real_manifest_v2() -> Option<PackageManifest> {
   let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
     .join("benches")
@@ -33,6 +36,23 @@ fn load_real_manifest_v2() -> Option<PackageManifest> {
   bincode::deserialize(&decompressed_data).ok()
 }
 
+#[allow(dead_code)]
+fn load_real_manifest_v3() -> Option<InternedPackageManifest> {
+  let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .join("benches")
+    .join("fixtures")
+    .join("api_manifest_v3.bin.zst");
+
+  if !path.exists() {
+    return None;
+  }
+
+  let compressed_data = fs::read(&path).ok()?;
+  let decompressed_data = zstd::decode_all(compressed_data.as_slice()).ok()?;
+  let serializable: SerializableInternedManifest = bincode::deserialize(&decompressed_data).ok()?;
+  serializable.try_into().ok()
+}
+
 fn benchmark_serialization(c: &mut Criterion) {
   let v1_packages = match load_real_manifest_v1() {
     Some(packages) => packages,
@@ -44,6 +64,7 @@ fn benchmark_serialization(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
 
   let mut group = c.benchmark_group("serialization");
   group.throughput(Throughput::Elements(v1_packages.len() as u64));
@@ -62,6 +83,14 @@ fn benchmark_serialization(c: &mut Criterion) {
     })
   });
 
+  group.bench_function("v3_format", |b| {
+    b.iter(|| {
+      let serializable: SerializableInternedManifest = black_box(&v3_manifest).into();
+      let serialized = bincode::serialize(&serializable).unwrap();
+      black_box(serialized)
+    })
+  });
+
   group.finish();
 }
 
@@ -76,9 +105,12 @@ fn benchmark_deserialization(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
+  let v3_serializable: SerializableInternedManifest = (&v3_manifest).into();
 
   let v1_serialized = bincode::serialize(&v1_packages).unwrap();
   let v2_serialized = bincode::serialize(&v2_manifest).unwrap();
+  let v3_serialized = bincode::serialize(&v3_serializable).unwrap();
 
   let mut group = c.benchmark_group("deserialization");
   group.throughput(Throughput::Elements(v1_packages.len() as u64));
@@ -97,6 +129,15 @@ fn benchmark_deserialization(c: &mut Criterion) {
     })
   });
 
+  group.bench_function("v3_format", |b| {
+    b.iter(|| {
+      let serializable: SerializableInternedManifest =
+        bincode::deserialize(black_box(&v3_serialized)).unwrap();
+      let deserialized: InternedPackageManifest = serializable.try_into().unwrap();
+      black_box(deserialized)
+    })
+  });
+
   group.finish();
 }
 
@@ -111,9 +152,12 @@ fn benchmark_compression(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
+  let v3_serializable: SerializableInternedManifest = (&v3_manifest).into();
 
   let v1_serialized = bincode::serialize(&v1_packages).unwrap();
   let v2_serialized = bincode::serialize(&v2_manifest).unwrap();
+  let v3_serialized = bincode::serialize(&v3_serializable).unwrap();
 
   let mut group = c.benchmark_group("compression");
 
@@ -128,6 +172,13 @@ fn benchmark_compression(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("v2_format", level), level, |b, &level| {
       b.iter(|| {
         let compressed = zstd::encode_all(black_box(v2_serialized.as_slice()), level).unwrap();
+        black_box(compressed)
+      })
+    });
+
+    group.bench_with_input(BenchmarkId::new("v3_format", level), level, |b, &level| {
+      b.iter(|| {
+        let compressed = zstd::encode_all(black_box(v3_serialized.as_slice()), level).unwrap();
         black_box(compressed)
       })
     });
@@ -147,15 +198,19 @@ fn benchmark_decompression(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
+  let v3_serializable: SerializableInternedManifest = (&v3_manifest).into();
 
   let v1_serialized = bincode::serialize(&v1_packages).unwrap();
   let v2_serialized = bincode::serialize(&v2_manifest).unwrap();
+  let v3_serialized = bincode::serialize(&v3_serializable).unwrap();
 
   let mut group = c.benchmark_group("decompression");
 
   for level in [3, 9].iter() {
     let v1_compressed = zstd::encode_all(v1_serialized.as_slice(), *level).unwrap();
     let v2_compressed = zstd::encode_all(v2_serialized.as_slice(), *level).unwrap();
+    let v3_compressed = zstd::encode_all(v3_serialized.as_slice(), *level).unwrap();
 
     group.bench_with_input(BenchmarkId::new("v1_format", level), level, |b, _level| {
       b.iter(|| {
@@ -167,6 +222,13 @@ fn benchmark_decompression(c: &mut Criterion) {
     group.bench_with_input(BenchmarkId::new("v2_format", level), level, |b, _level| {
       b.iter(|| {
         let decompressed = zstd::decode_all(black_box(v2_compressed.as_slice())).unwrap();
+        black_box(decompressed)
+      })
+    });
+
+    group.bench_with_input(BenchmarkId::new("v3_format", level), level, |b, _level| {
+      b.iter(|| {
+        let decompressed = zstd::decode_all(black_box(v3_compressed.as_slice())).unwrap();
         black_box(decompressed)
       })
     });
@@ -186,27 +248,56 @@ fn benchmark_conversion(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
 
   let mut group = c.benchmark_group("conversion");
   group.throughput(Throughput::Elements(v1_packages.len() as u64));
 
-  group.bench_function("vec_to_manifest", |b| {
+  group.bench_function("vec_to_v2_manifest", |b| {
     b.iter(|| {
       let manifest: PackageManifest = black_box(v1_packages.clone()).into();
       black_box(manifest)
     })
   });
 
-  group.bench_function("build_name_index", |b| {
+  group.bench_function("vec_to_v3_manifest", |b| {
+    b.iter(|| {
+      let manifest: InternedPackageManifest = black_box(v1_packages.clone()).into();
+      black_box(manifest)
+    })
+  });
+
+  group.bench_function("v2_to_v3_manifest", |b| {
+    b.iter(|| {
+      let manifest: InternedPackageManifest = black_box(v2_manifest.clone()).into();
+      black_box(manifest)
+    })
+  });
+
+  group.bench_function("v2_build_name_index", |b| {
     b.iter(|| {
       let index = black_box(&v2_manifest).build_name_index();
       black_box(index)
     })
   });
 
-  group.bench_function("get_package_by_name", |b| {
+  group.bench_function("v3_build_name_index", |b| {
+    b.iter(|| {
+      let index = black_box(&v3_manifest).build_name_index();
+      black_box(index)
+    })
+  });
+
+  group.bench_function("v2_get_package_by_name", |b| {
     b.iter(|| {
       let pkg = black_box(&v2_manifest).get_package_by_full_name("denikson-BepInExPack_Valheim");
+      black_box(pkg)
+    })
+  });
+
+  group.bench_function("v3_get_package_by_name", |b| {
+    b.iter(|| {
+      let pkg = black_box(&v3_manifest).get_package_by_full_name("denikson-BepInExPack_Valheim");
       black_box(pkg)
     })
   });
@@ -225,9 +316,12 @@ fn benchmark_size_comparison(c: &mut Criterion) {
   };
 
   let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.clone().into();
+  let v3_serializable: SerializableInternedManifest = (&v3_manifest).into();
 
   let v1_serialized = bincode::serialize(&v1_packages).unwrap();
   let v2_serialized = bincode::serialize(&v2_manifest).unwrap();
+  let v3_serialized = bincode::serialize(&v3_serializable).unwrap();
 
   println!("\n=== Size Comparison Report ===");
   println!("Packages: {}", v1_packages.len());
@@ -235,24 +329,47 @@ fn benchmark_size_comparison(c: &mut Criterion) {
     "Total versions: {}",
     v1_packages.iter().map(|p| p.versions.len()).sum::<usize>()
   );
+  println!(
+    "String table size: {} unique strings",
+    v3_serializable.string_table.len()
+  );
   println!("\nSerialized (bincode):");
   println!("  V1 format: {} bytes", v1_serialized.len());
   println!("  V2 format: {} bytes", v2_serialized.len());
+  println!("  V3 format: {} bytes", v3_serialized.len());
   println!(
-    "  Reduction: {:.1}%",
+    "  V2 vs V1: {:.1}%",
     (1.0 - v2_serialized.len() as f64 / v1_serialized.len() as f64) * 100.0
+  );
+  println!(
+    "  V3 vs V1: {:.1}%",
+    (1.0 - v3_serialized.len() as f64 / v1_serialized.len() as f64) * 100.0
+  );
+  println!(
+    "  V3 vs V2: {:.1}%",
+    (1.0 - v3_serialized.len() as f64 / v2_serialized.len() as f64) * 100.0
   );
 
   for level in [3, 9] {
     let v1_compressed = zstd::encode_all(v1_serialized.as_slice(), level).unwrap();
     let v2_compressed = zstd::encode_all(v2_serialized.as_slice(), level).unwrap();
+    let v3_compressed = zstd::encode_all(v3_serialized.as_slice(), level).unwrap();
 
     println!("\nCompressed (zstd level {}):", level);
     println!("  V1 format: {} bytes", v1_compressed.len());
     println!("  V2 format: {} bytes", v2_compressed.len());
+    println!("  V3 format: {} bytes", v3_compressed.len());
     println!(
-      "  Reduction: {:.1}%",
+      "  V2 vs V1: {:.1}%",
       (1.0 - v2_compressed.len() as f64 / v1_compressed.len() as f64) * 100.0
+    );
+    println!(
+      "  V3 vs V1: {:.1}%",
+      (1.0 - v3_compressed.len() as f64 / v1_compressed.len() as f64) * 100.0
+    );
+    println!(
+      "  V3 vs V2: {:.1}%",
+      (1.0 - v3_compressed.len() as f64 / v2_compressed.len() as f64) * 100.0
     );
     println!(
       "  V1 compression ratio: {:.2}x",
@@ -261,6 +378,10 @@ fn benchmark_size_comparison(c: &mut Criterion) {
     println!(
       "  V2 compression ratio: {:.2}x",
       v2_serialized.len() as f64 / v2_compressed.len() as f64
+    );
+    println!(
+      "  V3 compression ratio: {:.2}x",
+      v3_serialized.len() as f64 / v3_compressed.len() as f64
     );
   }
 

--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use std::fs;
 use std::path::PathBuf;
-use valheim_mod_manager::package::{Package, PackageManifest};
+use valheim_mod_manager::package::{InternedPackageManifest, Package, PackageManifest};
 
 fn load_real_manifest_v1() -> Option<Vec<Package>> {
   let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -18,7 +18,7 @@ fn load_real_manifest_v1() -> Option<Vec<Package>> {
   bincode::deserialize(&decompressed_data).ok()
 }
 
-fn search_soa_direct(manifest: &PackageManifest, term: &str) -> Vec<usize> {
+fn search_v2_direct(manifest: &PackageManifest, term: &str) -> Vec<usize> {
   (0..manifest.len())
     .filter(|&idx| {
       if let Some(name) = &manifest.names[idx] {
@@ -38,6 +38,26 @@ fn search_soa_direct(manifest: &PackageManifest, term: &str) -> Vec<usize> {
     .collect()
 }
 
+fn search_v3_direct(manifest: &InternedPackageManifest, term: &str) -> Vec<usize> {
+  (0..manifest.len())
+    .filter(|&idx| {
+      if let Some(name) = manifest.resolve_name_at(idx) {
+        if name.to_lowercase().contains(term) {
+          return true;
+        }
+      }
+
+      if let Some(full_name) = manifest.resolve_full_name_at(idx) {
+        if full_name.to_lowercase().contains(term) {
+          return true;
+        }
+      }
+
+      false
+    })
+    .collect()
+}
+
 fn benchmark_search_common_term(c: &mut Criterion) {
   let v1_packages = match load_real_manifest_v1() {
     Some(packages) => packages,
@@ -47,16 +67,24 @@ fn benchmark_search_common_term(c: &mut Criterion) {
     }
   };
 
-  let soa_manifest: PackageManifest = v1_packages.into();
+  let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.into();
 
   let search_term = "mod";
 
   let mut group = c.benchmark_group("search_common_term");
-  group.throughput(Throughput::Elements(soa_manifest.len() as u64));
+  group.throughput(Throughput::Elements(v2_manifest.len() as u64));
 
-  group.bench_function("soa_direct", |b| {
+  group.bench_function("v2_direct", |b| {
     b.iter(|| {
-      let results = search_soa_direct(black_box(&soa_manifest), black_box(search_term));
+      let results = search_v2_direct(black_box(&v2_manifest), black_box(search_term));
+      black_box(results)
+    })
+  });
+
+  group.bench_function("v3_direct", |b| {
+    b.iter(|| {
+      let results = search_v3_direct(black_box(&v3_manifest), black_box(search_term));
       black_box(results)
     })
   });
@@ -73,16 +101,24 @@ fn benchmark_search_rare_term(c: &mut Criterion) {
     }
   };
 
-  let soa_manifest: PackageManifest = v1_packages.into();
+  let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.into();
 
   let search_term = "xyzzyx";
 
   let mut group = c.benchmark_group("search_rare_term");
-  group.throughput(Throughput::Elements(soa_manifest.len() as u64));
+  group.throughput(Throughput::Elements(v2_manifest.len() as u64));
 
-  group.bench_function("soa_direct", |b| {
+  group.bench_function("v2_direct", |b| {
     b.iter(|| {
-      let results = search_soa_direct(black_box(&soa_manifest), black_box(search_term));
+      let results = search_v2_direct(black_box(&v2_manifest), black_box(search_term));
+      black_box(results)
+    })
+  });
+
+  group.bench_function("v3_direct", |b| {
+    b.iter(|| {
+      let results = search_v3_direct(black_box(&v3_manifest), black_box(search_term));
       black_box(results)
     })
   });
@@ -99,23 +135,24 @@ fn benchmark_search_with_display(c: &mut Criterion) {
     }
   };
 
-  let soa_manifest: PackageManifest = v1_packages.into();
+  let v2_manifest: PackageManifest = v1_packages.clone().into();
+  let v3_manifest: InternedPackageManifest = v1_packages.into();
 
   let search_term = "tool";
 
   let mut group = c.benchmark_group("search_with_display");
 
-  group.bench_function("soa_search_and_access", |b| {
+  group.bench_function("v2_search_and_access", |b| {
     b.iter(|| {
-      let results: Vec<_> = (0..soa_manifest.len())
+      let results: Vec<_> = (0..v2_manifest.len())
         .filter(|&idx| {
-          if let Some(name) = &soa_manifest.names[idx] {
+          if let Some(name) = &v2_manifest.names[idx] {
             if name.to_lowercase().contains(search_term) {
               return true;
             }
           }
 
-          if let Some(full_name) = &soa_manifest.full_names[idx] {
+          if let Some(full_name) = &v2_manifest.full_names[idx] {
             if full_name.to_lowercase().contains(search_term) {
               return true;
             }
@@ -124,19 +161,64 @@ fn benchmark_search_with_display(c: &mut Criterion) {
           false
         })
         .map(|idx| {
-          let (ver_start, ver_end) = soa_manifest.version_ranges[idx];
+          let (ver_start, ver_end) = v2_manifest.version_ranges[idx];
 
           let latest_ver_idx = (ver_start..ver_end)
-            .max_by_key(|&ver_idx| soa_manifest.versions.dates_created[ver_idx])
+            .max_by_key(|&ver_idx| v2_manifest.versions.dates_created[ver_idx])
             .unwrap_or(ver_start);
 
-          let version = soa_manifest.versions.version_numbers[latest_ver_idx]
+          let version = v2_manifest.versions.version_numbers[latest_ver_idx]
             .as_deref()
             .unwrap_or("Unknown");
 
-          let name = soa_manifest.names[idx].as_deref().unwrap_or("Unknown");
+          let name = v2_manifest.names[idx].as_deref().unwrap_or("Unknown");
 
-          let owner = soa_manifest.owners[idx].as_deref().unwrap_or("Unknown");
+          let owner = v2_manifest.owners[idx].as_deref().unwrap_or("Unknown");
+
+          (owner, name, version)
+        })
+        .collect();
+
+      black_box(results)
+    })
+  });
+
+  group.bench_function("v3_search_and_access", |b| {
+    b.iter(|| {
+      let results: Vec<_> = (0..v3_manifest.len())
+        .filter(|&idx| {
+          if let Some(name) = v3_manifest.resolve_name_at(idx) {
+            if name.to_lowercase().contains(search_term) {
+              return true;
+            }
+          }
+
+          if let Some(full_name) = v3_manifest.resolve_full_name_at(idx) {
+            if full_name.to_lowercase().contains(search_term) {
+              return true;
+            }
+          }
+
+          false
+        })
+        .map(|idx| {
+          let (ver_start, ver_end) = v3_manifest.version_ranges[idx];
+
+          let latest_ver_idx = (ver_start..ver_end)
+            .max_by_key(|&ver_idx| v3_manifest.versions.dates_created[ver_idx])
+            .unwrap_or(ver_start);
+
+          let version = v3_manifest.versions.version_numbers[latest_ver_idx]
+            .map(|key| v3_manifest.interner.resolve(&key).to_string())
+            .unwrap_or_else(|| "Unknown".to_string());
+
+          let name = v3_manifest
+            .resolve_name_at(idx)
+            .unwrap_or_else(|| "Unknown".to_string());
+
+          let owner = v3_manifest
+            .resolve_owner_at(idx)
+            .unwrap_or_else(|| "Unknown".to_string());
 
           (owner, name, version)
         })

--- a/examples/generate-fixtures.rs
+++ b/examples/generate-fixtures.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 use valheim_mod_manager::api;
-use valheim_mod_manager::package::Package;
+use valheim_mod_manager::package::{Package, PackageManifest, SerializableInternedManifest};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,25 +25,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
   fs::create_dir_all(&fixtures_dir)?;
 
-  println!("Generating v2 format fixture...");
-  let v2_data = bincode::serialize(&manifest)?;
-  let v2_compressed = zstd::encode_all(v2_data.as_slice(), 9)?;
-  let v2_path = fixtures_dir.join("api_manifest_v2.bin.zst");
-  fs::write(&v2_path, v2_compressed)?;
-  println!("  ✓ Written to benches/fixtures/api_manifest_v2.bin.zst");
-  println!("  ✓ Size: {} bytes", fs::metadata(&v2_path)?.len());
+  println!("Generating v3 format fixture (interned strings)...");
+  let serializable: SerializableInternedManifest = (&manifest).into();
+  let v3_data = bincode::serialize(&serializable)?;
+  let v3_compressed = zstd::encode_all(v3_data.as_slice(), 9)?;
+  let v3_path = fixtures_dir.join("api_manifest_v3.bin.zst");
+  fs::write(&v3_path, &v3_compressed)?;
+  println!("  ✓ Written to benches/fixtures/api_manifest_v3.bin.zst");
+  println!("  ✓ Size: {} bytes", fs::metadata(&v3_path)?.len());
   println!();
 
-  println!("Generating v1 format fixture (converting from v2)...");
+  println!("Generating v1 format fixture (converting from v3)...");
   let v1_packages: Vec<Package> = (0..manifest.len())
     .map(|idx| manifest.get_package_at(idx))
     .collect();
   let v1_data = bincode::serialize(&v1_packages)?;
   let v1_compressed = zstd::encode_all(v1_data.as_slice(), 3)?;
   let v1_path = fixtures_dir.join("api_manifest.bin.zst");
-  fs::write(&v1_path, v1_compressed)?;
+  fs::write(&v1_path, &v1_compressed)?;
   println!("  ✓ Written to benches/fixtures/api_manifest.bin.zst");
   println!("  ✓ Size: {} bytes", fs::metadata(&v1_path)?.len());
+  println!();
+
+  println!("Generating v2 format fixture (struct-of-arrays)...");
+  let v1_for_v2: Vec<Package> = bincode::deserialize(&v1_data)?;
+  let v2_manifest: PackageManifest = v1_for_v2.into();
+  let v2_data = bincode::serialize(&v2_manifest)?;
+  let v2_compressed = zstd::encode_all(v2_data.as_slice(), 3)?;
+  let v2_path = fixtures_dir.join("api_manifest_v2.bin.zst");
+  fs::write(&v2_path, &v2_compressed)?;
+  println!("  ✓ Written to benches/fixtures/api_manifest_v2.bin.zst");
+  println!("  ✓ Size: {} bytes", fs::metadata(&v2_path)?.len());
   println!();
 
   println!("✓ Fixtures generated successfully!");

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,7 @@
 use crate::error::{AppError, AppResult};
-use crate::package::{Package, PackageManifest};
+use crate::package::{
+  InternedPackageManifest, Package, PackageManifest, SerializableInternedManifest,
+};
 
 use chrono::prelude::*;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -14,10 +16,19 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const API_URL: &str = "https://stacklands.thunderstore.io/c/valheim/api/v1/package/";
 const LAST_MODIFIED_FILENAME: &str = "last_modified";
-const API_MANIFEST_FILENAME: &str = "api_manifest_v2.bin.zst";
+const API_MANIFEST_FILENAME_V3: &str = "api_manifest_v3.bin.zst";
+const API_MANIFEST_FILENAME_V2: &str = "api_manifest_v2.bin.zst";
 const API_MANIFEST_FILENAME_V1: &str = "api_manifest.bin.zst";
 
 /// Returns the path to the last_modified file in the cache directory.
+///
+/// # Parameters
+///
+/// * `cache_dir` - The cache directory path (supports tilde expansion)
+///
+/// # Returns
+///
+/// The full path to the last_modified file
 fn last_modified_path(cache_dir: &str) -> PathBuf {
   let expanded_path = shellexpand::tilde(cache_dir);
   let mut path = PathBuf::from(expanded_path.as_ref());
@@ -25,15 +36,47 @@ fn last_modified_path(cache_dir: &str) -> PathBuf {
   path
 }
 
-/// Returns the path to the api_manifest file in the cache directory.
-fn api_manifest_path(cache_dir: &str) -> PathBuf {
+/// Returns the path to the v3 API manifest file in the cache directory.
+///
+/// # Parameters
+///
+/// * `cache_dir` - The cache directory path (supports tilde expansion)
+///
+/// # Returns
+///
+/// The full path to the v3 manifest file
+fn api_manifest_path_v3(cache_dir: &str) -> PathBuf {
   let expanded_path = shellexpand::tilde(cache_dir);
   let mut path = PathBuf::from(expanded_path.as_ref());
-  path.push(API_MANIFEST_FILENAME);
+  path.push(API_MANIFEST_FILENAME_V3);
   path
 }
 
-/// Returns the path to the old v1 api_manifest file in the cache directory.
+/// Returns the path to the v2 API manifest file in the cache directory.
+///
+/// # Parameters
+///
+/// * `cache_dir` - The cache directory path (supports tilde expansion)
+///
+/// # Returns
+///
+/// The full path to the v2 manifest file
+fn api_manifest_path_v2(cache_dir: &str) -> PathBuf {
+  let expanded_path = shellexpand::tilde(cache_dir);
+  let mut path = PathBuf::from(expanded_path.as_ref());
+  path.push(API_MANIFEST_FILENAME_V2);
+  path
+}
+
+/// Returns the path to the v1 API manifest file in the cache directory.
+///
+/// # Parameters
+///
+/// * `cache_dir` - The cache directory path (supports tilde expansion)
+///
+/// # Returns
+///
+/// The full path to the v1 manifest file
 fn api_manifest_path_v1(cache_dir: &str) -> PathBuf {
   let expanded_path = shellexpand::tilde(cache_dir);
   let mut path = PathBuf::from(expanded_path.as_ref());
@@ -54,7 +97,7 @@ fn api_manifest_path_v1(cache_dir: &str) -> PathBuf {
 ///
 /// # Returns
 ///
-/// A `PackageManifest` containing all available packages in SoA format.
+/// An `InternedPackageManifest` containing all available packages in SoA format with interned strings.
 ///
 /// # Errors
 ///
@@ -62,7 +105,10 @@ fn api_manifest_path_v1(cache_dir: &str) -> PathBuf {
 /// - Failed to check or retrieve last modified dates
 /// - Network request fails
 /// - Parsing fails
-pub async fn get_manifest(cache_dir: &str, api_url: Option<&str>) -> AppResult<PackageManifest> {
+pub async fn get_manifest(
+  cache_dir: &str,
+  api_url: Option<&str>,
+) -> AppResult<InternedPackageManifest> {
   let api_url = api_url.unwrap_or(API_URL);
   let last_modified = local_last_modified(cache_dir).await?;
   tracing::info!("Manifest last modified: {}", last_modified);
@@ -78,24 +124,47 @@ pub async fn get_manifest(cache_dir: &str, api_url: Option<&str>) -> AppResult<P
 
 /// Reads the cached API manifest from disk.
 ///
-/// Attempts to read the new v2 format first, falls back to v1 format if needed.
-/// When v1 format is detected, it automatically migrates to v2.
+/// Attempts to read formats in order: v3 (interned), v2 (SoA), v1 (`Vec<Package>`).
+/// When older formats are detected, they are automatically migrated to v3.
 ///
 /// # Returns
 ///
-/// The deserialized manifest as a PackageManifest.
+/// The deserialized manifest as an InternedPackageManifest.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - The file cannot be opened or read
 /// - The data cannot be decompressed or deserialized
-async fn get_manifest_from_disk(cache_dir: &str) -> AppResult<PackageManifest> {
-  let path_v2 = api_manifest_path(cache_dir);
+async fn get_manifest_from_disk(cache_dir: &str) -> AppResult<InternedPackageManifest> {
+  let path_v3 = api_manifest_path_v3(cache_dir);
+  let path_v2 = api_manifest_path_v2(cache_dir);
   let path_v1 = api_manifest_path_v1(cache_dir);
 
+  if path_v3.exists() {
+    tracing::debug!("Loading v3 manifest format");
+
+    let mut file = fs::File::open(&path_v3).await?;
+    let mut compressed_data = Vec::new();
+    file.read_to_end(&mut compressed_data).await?;
+
+    let decompressed_data = zstd::decode_all(compressed_data.as_slice())
+      .map_err(|e| AppError::Manifest(format!("Failed to decompress v3 manifest: {}", e)))?;
+
+    let serializable: SerializableInternedManifest = bincode::deserialize(&decompressed_data)
+      .map_err(|e| AppError::Manifest(format!("Failed to deserialize v3 manifest: {}", e)))?;
+
+    let manifest: InternedPackageManifest = serializable.into();
+
+    manifest
+      .validate()
+      .map_err(|e| AppError::Manifest(format!("V3 manifest validation failed: {}", e)))?;
+
+    return Ok(manifest);
+  }
+
   if path_v2.exists() {
-    tracing::debug!("Loading v2 manifest format");
+    tracing::info!("Found v2 manifest, migrating to v3 format");
 
     let mut file = fs::File::open(&path_v2).await?;
     let mut compressed_data = Vec::new();
@@ -104,69 +173,103 @@ async fn get_manifest_from_disk(cache_dir: &str) -> AppResult<PackageManifest> {
     let decompressed_data = zstd::decode_all(compressed_data.as_slice())
       .map_err(|e| AppError::Manifest(format!("Failed to decompress v2 manifest: {}", e)))?;
 
-    let manifest: PackageManifest = bincode::deserialize(&decompressed_data)
+    let v2_manifest: PackageManifest = bincode::deserialize(&decompressed_data)
       .map_err(|e| AppError::Manifest(format!("Failed to deserialize v2 manifest: {}", e)))?;
 
-    manifest
-      .validate()
-      .map_err(|e| AppError::Manifest(format!("V2 manifest validation failed: {}", e)))?;
+    let manifest: InternedPackageManifest = v2_manifest.into();
 
-    Ok(manifest)
-  } else {
-    if path_v1.exists() {
-      tracing::info!("Found v1 manifest, migrating to v2 format");
+    manifest.validate().map_err(|e| {
+      AppError::Manifest(format!(
+        "V3 manifest validation failed during migration: {}",
+        e
+      ))
+    })?;
 
-      let mut file = fs::File::open(&path_v1).await?;
-      let mut compressed_data = Vec::new();
-      file.read_to_end(&mut compressed_data).await?;
+    let serializable: SerializableInternedManifest = (&manifest).into();
+    let binary_data = bincode::serialize(&serializable)
+      .map_err(|e| AppError::Manifest(format!("Failed to serialize v3 manifest: {}", e)))?;
 
-      let decompressed_data = zstd::decode_all(compressed_data.as_slice())
-        .map_err(|e| AppError::Manifest(format!("Failed to decompress v1 manifest: {}", e)))?;
+    write_cache_to_disk(path_v3.clone(), &binary_data, true).await?;
 
-      let packages: Vec<Package> = bincode::deserialize(&decompressed_data)
-        .map_err(|e| AppError::Manifest(format!("Failed to deserialize v1 manifest: {}", e)))?;
+    match tokio::fs::metadata(&path_v3).await {
+      Ok(metadata) if metadata.len() > 0 => {
+        tracing::info!("V3 manifest written successfully, removing v2");
 
-      let manifest: PackageManifest = packages.into();
-
-      manifest.validate().map_err(|e| {
-        AppError::Manifest(format!(
-          "V2 manifest validation failed during migration: {}",
-          e
-        ))
-      })?;
-
-      let binary_data = bincode::serialize(&manifest)
-        .map_err(|e| AppError::Manifest(format!("Failed to serialize v2 manifest: {}", e)))?;
-
-      write_cache_to_disk(path_v2.clone(), &binary_data, true).await?;
-
-      match tokio::fs::metadata(&path_v2).await {
-        Ok(metadata) if metadata.len() > 0 => {
-          tracing::info!("V2 manifest written successfully, removing v1");
-
-          if let Err(e) = fs::remove_file(&path_v1).await {
-            tracing::warn!(
-              "Failed to remove old v1 manifest (keeping as backup): {}",
-              e
-            );
-          }
-        }
-        Ok(_) => {
-          tracing::error!("V2 manifest written but is empty, keeping v1 as backup");
-        }
-        Err(e) => {
-          tracing::error!(
-            "Failed to verify v2 manifest write: {}, keeping v1 as backup",
+        if let Err(e) = fs::remove_file(&path_v2).await {
+          tracing::warn!(
+            "Failed to remove old v2 manifest (keeping as backup): {}",
             e
           );
         }
       }
-
-      return Ok(manifest);
+      Ok(_) => {
+        tracing::error!("V3 manifest written but is empty, keeping v2 as backup");
+      }
+      Err(e) => {
+        tracing::error!(
+          "Failed to verify v3 manifest write: {}, keeping v2 as backup",
+          e
+        );
+      }
     }
 
-    Err(AppError::Manifest("No cached manifest found".to_string()))
+    return Ok(manifest);
   }
+
+  if path_v1.exists() {
+    tracing::info!("Found v1 manifest, migrating to v3 format");
+
+    let mut file = fs::File::open(&path_v1).await?;
+    let mut compressed_data = Vec::new();
+    file.read_to_end(&mut compressed_data).await?;
+
+    let decompressed_data = zstd::decode_all(compressed_data.as_slice())
+      .map_err(|e| AppError::Manifest(format!("Failed to decompress v1 manifest: {}", e)))?;
+
+    let packages: Vec<Package> = bincode::deserialize(&decompressed_data)
+      .map_err(|e| AppError::Manifest(format!("Failed to deserialize v1 manifest: {}", e)))?;
+
+    let manifest: InternedPackageManifest = packages.into();
+
+    manifest.validate().map_err(|e| {
+      AppError::Manifest(format!(
+        "V3 manifest validation failed during migration: {}",
+        e
+      ))
+    })?;
+
+    let serializable: SerializableInternedManifest = (&manifest).into();
+    let binary_data = bincode::serialize(&serializable)
+      .map_err(|e| AppError::Manifest(format!("Failed to serialize v3 manifest: {}", e)))?;
+
+    write_cache_to_disk(path_v3.clone(), &binary_data, true).await?;
+
+    match tokio::fs::metadata(&path_v3).await {
+      Ok(metadata) if metadata.len() > 0 => {
+        tracing::info!("V3 manifest written successfully, removing v1");
+
+        if let Err(e) = fs::remove_file(&path_v1).await {
+          tracing::warn!(
+            "Failed to remove old v1 manifest (keeping as backup): {}",
+            e
+          );
+        }
+      }
+      Ok(_) => {
+        tracing::error!("V3 manifest written but is empty, keeping v1 as backup");
+      }
+      Err(e) => {
+        tracing::error!(
+          "Failed to verify v3 manifest write: {}, keeping v1 as backup",
+          e
+        );
+      }
+    }
+
+    return Ok(manifest);
+  }
+
+  Err(AppError::Manifest("No cached manifest found".to_string()))
 }
 
 /// Downloads the manifest from the API server and filters out unnecessary fields.
@@ -229,7 +332,7 @@ async fn get_manifest_from_network(
 ///
 /// This function retrieves the manifest from the API server and saves both
 /// the manifest content and the last modified date to disk.
-/// The manifest is converted to the SoA format before caching.
+/// The manifest is converted to the interned V3 format before caching.
 ///
 /// # Parameters
 ///
@@ -238,7 +341,7 @@ async fn get_manifest_from_network(
 ///
 /// # Returns
 ///
-/// The manifest data as PackageManifest.
+/// The manifest data as InternedPackageManifest.
 ///
 /// # Errors
 ///
@@ -248,7 +351,7 @@ async fn get_manifest_from_network(
 async fn get_manifest_from_network_and_cache(
   cache_dir: &str,
   api_url: &str,
-) -> AppResult<PackageManifest> {
+) -> AppResult<InternedPackageManifest> {
   let results = get_manifest_from_network(api_url).await?;
   let packages = results.0;
   let last_modified_from_network = results.1;
@@ -260,11 +363,12 @@ async fn get_manifest_from_network_and_cache(
   )
   .await?;
 
-  let manifest: PackageManifest = packages.into();
-  let binary_data = bincode::serialize(&manifest)
+  let manifest: InternedPackageManifest = packages.into();
+  let serializable: SerializableInternedManifest = (&manifest).into();
+  let binary_data = bincode::serialize(&serializable)
     .map_err(|e| AppError::Manifest(format!("Failed to serialize manifest: {}", e)))?;
 
-  write_cache_to_disk(api_manifest_path(cache_dir), &binary_data, true).await?;
+  write_cache_to_disk(api_manifest_path_v3(cache_dir), &binary_data, true).await?;
 
   Ok(manifest)
 }
@@ -338,13 +442,19 @@ async fn network_last_modified(api_url: &str) -> AppResult<DateTime<FixedOffset>
   Ok(last_modified_date)
 }
 
-/// Checks if the cached manifest file exists.
+/// Checks for the existence of any version of the cached manifest file (v1, v2, or v3).
+///
+/// # Parameters
+///
+/// * `cache_dir` - The cache directory path
 ///
 /// # Returns
 ///
-/// `true` if the api_manifest file exists, `false` otherwise.
+/// `true` if any api_manifest file exists, `false` otherwise.
 fn api_manifest_file_exists(cache_dir: &str) -> bool {
-  api_manifest_path(cache_dir).exists()
+  api_manifest_path_v3(cache_dir).exists()
+    || api_manifest_path_v2(cache_dir).exists()
+    || api_manifest_path_v1(cache_dir).exists()
 }
 
 /// Writes data to a cache file on disk.
@@ -584,7 +694,7 @@ mod tests {
     assert!(!api_manifest_file_exists(temp_dir_str));
 
     let mut path = PathBuf::from(temp_dir_str);
-    path.push(API_MANIFEST_FILENAME);
+    path.push(API_MANIFEST_FILENAME_V3);
     let _ = File::create(path).unwrap();
 
     assert!(api_manifest_file_exists(temp_dir_str));
@@ -597,7 +707,7 @@ mod tests {
     let expected_path = Path::new(&home_dir).join("some_test_dir");
 
     let last_modified = last_modified_path(home_path);
-    let api_manifest = api_manifest_path(home_path);
+    let api_manifest = api_manifest_path_v3(home_path);
 
     assert_eq!(last_modified.parent().unwrap(), expected_path);
     assert_eq!(api_manifest.parent().unwrap(), expected_path);
@@ -746,11 +856,12 @@ mod tests {
     };
 
     let packages = vec![package];
-    let manifest: PackageManifest = packages.into();
-    let binary_data = bincode::serialize(&manifest).unwrap();
+    let interned_manifest: InternedPackageManifest = packages.into();
+    let serializable: SerializableInternedManifest = (&interned_manifest).into();
+    let binary_data = bincode::serialize(&serializable).unwrap();
     let compressed_data = zstd::encode_all(binary_data.as_slice(), 9).unwrap();
     let mut path = PathBuf::from(temp_dir_str);
-    path.push(API_MANIFEST_FILENAME);
+    path.push(API_MANIFEST_FILENAME_V3);
     let mut file = File::create(path).unwrap();
     file.write_all(&compressed_data).unwrap();
 
@@ -758,7 +869,10 @@ mod tests {
     let manifest = rt.block_on(get_manifest_from_disk(temp_dir_str)).unwrap();
 
     assert_eq!(manifest.len(), 1);
-    assert_eq!(manifest.full_names[0], Some("Owner-ModA".to_string()));
+    assert_eq!(
+      manifest.resolve_full_name_at(0),
+      Some("Owner-ModA".to_string())
+    );
   }
 
   #[test]
@@ -767,7 +881,7 @@ mod tests {
     let temp_dir_str = temp_dir.path().to_str().unwrap();
 
     let mut path = PathBuf::from(temp_dir_str);
-    path.push(API_MANIFEST_FILENAME);
+    path.push(API_MANIFEST_FILENAME_V3);
     let mut file = File::create(path).unwrap();
     file
       .write_all(b"This is not valid compressed data")
@@ -888,14 +1002,15 @@ mod tests {
     };
 
     let packages = vec![package];
-    let manifest: PackageManifest = packages.into();
-    let binary_data = bincode::serialize(&manifest).unwrap();
+    let interned_manifest: InternedPackageManifest = packages.into();
+    let serializable: SerializableInternedManifest = (&interned_manifest).into();
+    let binary_data = bincode::serialize(&serializable).unwrap();
     let compressed_data = zstd::encode_all(binary_data.as_slice(), 9).unwrap();
 
     std::fs::create_dir_all(PathBuf::from(temp_dir_str)).unwrap();
 
     let mut manifest_path = PathBuf::from(temp_dir_str);
-    manifest_path.push(API_MANIFEST_FILENAME);
+    manifest_path.push(API_MANIFEST_FILENAME_V3);
     let mut file = File::create(manifest_path).unwrap();
     file.write_all(&compressed_data).unwrap();
 
@@ -945,7 +1060,7 @@ mod tests {
     let mut file = File::create(&v1_path).unwrap();
     file.write_all(&compressed_data).unwrap();
 
-    let v2_path = PathBuf::from(temp_dir_str).join(API_MANIFEST_FILENAME);
+    let v2_path = PathBuf::from(temp_dir_str).join(API_MANIFEST_FILENAME_V3);
     assert!(!v2_path.exists());
     assert!(v1_path.exists());
 
@@ -955,9 +1070,12 @@ mod tests {
     assert!(result.is_ok());
     let manifest = result.unwrap();
     assert_eq!(manifest.len(), 1);
-    assert_eq!(manifest.full_names[0], Some("OldOwner-OldMod".to_string()));
+    assert_eq!(
+      manifest.resolve_full_name_at(0),
+      Some("OldOwner-OldMod".to_string())
+    );
 
-    assert!(v2_path.exists(), "v2 manifest should be created");
+    assert!(v2_path.exists(), "v3 manifest should be created");
     assert!(!v1_path.exists(), "v1 manifest should be removed");
   }
 
@@ -1019,10 +1137,13 @@ mod tests {
     assert!(result.is_ok());
     if let Ok(manifest) = result {
       assert_eq!(manifest.len(), 1);
-      assert_eq!(manifest.full_names[0], Some("Owner-ModA".to_string()));
+      assert_eq!(
+        manifest.resolve_full_name_at(0),
+        Some("Owner-ModA".to_string())
+      );
 
       assert!(last_modified_path(temp_dir_str).exists());
-      assert!(api_manifest_path(temp_dir_str).exists());
+      assert!(api_manifest_path_v3(temp_dir_str).exists());
 
       let last_mod_content = std::fs::read_to_string(last_modified_path(temp_dir_str)).unwrap();
       assert!(last_mod_content.contains("21 Feb 2024 15:30:45"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,37 +1,47 @@
 use clap::{Args, Parser, Subcommand};
 
+/// Root command-line interface structure for the application.
+///
+/// This struct uses clap's derive macros to parse command-line arguments
+/// and route to the appropriate subcommand handler.
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct AppCli {
+  /// The subcommand to execute.
   #[command(subcommand)]
   pub command: Command,
 }
 
+/// Top-level commands available to the user.
 #[derive(Subcommand)]
 pub enum Command {
-  /// Update the mod manifest or installed mods
+  /// Update the mod manifest or installed mods.
   Update(CommandArgs),
-  /// Search for mods by name
+  /// Search for mods by name.
   Search(SearchArgs),
 }
 
+/// Arguments for the update command.
 #[derive(Args)]
 pub struct CommandArgs {
+  /// The specific update operation to perform.
   #[command(subcommand)]
   pub command: UpdatesCommand,
 }
 
+/// Arguments for the search command.
 #[derive(Args)]
 pub struct SearchArgs {
-  /// Search term to find mods by name
+  /// Search term to find mods by name.
   pub term: String,
 }
 
+/// Subcommands for the update operation.
 #[derive(Subcommand)]
 pub enum UpdatesCommand {
-  /// Update the mod manifest from the server
+  /// Update the mod manifest from the server.
   Manifest,
-  /// Update installed mods to their latest versions
+  /// Update installed mods to their latest versions.
   Mods,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,19 @@ use std::{fs::OpenOptions, path::Path};
 
 use crate::error::{AppError, AppResult};
 
+/// Application configuration loaded from vmm_config.toml.
+///
+/// This structure defines all user-configurable settings for the Valheim Mod Manager,
+/// including which mods to manage, logging preferences, and file system paths.
 #[derive(Serialize, Deserialize)]
 pub struct AppConfig {
+  /// List of mods to install and manage, specified as "Owner-ModName" strings.
   pub mod_list: Vec<String>,
+  /// Logging level (e.g., "error", "warn", "info", "debug", "trace").
   pub log_level: String,
+  /// Directory path for caching downloaded manifests and mod files.
   pub cache_dir: String,
+  /// Optional directory path where mods should be installed.
   pub install_dir: Option<String>,
 }
 
@@ -25,15 +33,26 @@ impl Default for AppConfig {
   }
 }
 
+/// Global application configuration instance.
+///
+/// This static is lazily initialized on first access by reading from vmm_config.toml
+/// or creating a new config file with default values if none exists.
+///
+/// # Panics
+///
+/// Panics if the configuration file cannot be read or parsed.
 #[cfg(not(tarpaulin_include))]
 pub static APP_CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {
   get_config().unwrap_or_else(|err| panic!("An error has occurred getting the config: '{err}'"))
 });
 
-/// Returns a new ConfigData.
+/// Loads application configuration from vmm_config.toml.
 ///
-/// If a config.toml didn't already exist
-/// a new one is created and set with default values.
+/// If a config.toml doesn't already exist, a new one is created with default values.
+///
+/// # Returns
+///
+/// The loaded configuration, or an error if reading/parsing fails.
 #[cfg(not(tarpaulin_include))]
 fn get_config() -> Result<AppConfig, ConfigError> {
   let default_config_data = AppConfig::default();
@@ -54,7 +73,16 @@ fn get_config() -> Result<AppConfig, ConfigError> {
     .try_deserialize()
 }
 
-/// Creates a new config file with their default values.
+/// Creates a new configuration file with default values.
+///
+/// # Parameters
+///
+/// * `config_path` - Path where the config file should be created
+/// * `default_config_data` - Default configuration values to serialize
+///
+/// # Returns
+///
+/// `Ok(())` on success, or an error if file creation or serialization fails.
 fn create_missing_config_file(
   config_path: &Path,
   default_config_data: &AppConfig,

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,0 +1,135 @@
+use lasso::{Rodeo, Spur};
+
+/// Type alias for the string interner (lasso::Rodeo).
+///
+/// The interner stores unique strings and returns small integer keys that can be
+/// used to retrieve them later, reducing memory usage for repeated strings.
+pub type StringInterner = Rodeo;
+
+/// Type alias for interned string keys (lasso::Spur).
+///
+/// These keys are compact integer identifiers that reference strings stored in
+/// a StringInterner.
+pub type InternKey = Spur;
+
+/// Interns an optional string value.
+///
+/// # Parameters
+///
+/// * `interner` - The string interner to use
+/// * `s` - Optional string slice to intern
+///
+/// # Returns
+///
+/// An optional intern key, or None if the input was None.
+pub fn intern_option(interner: &mut StringInterner, s: Option<&str>) -> Option<InternKey> {
+  s.map(|val| interner.get_or_intern(val))
+}
+
+/// Resolves an optional interned key back to a String.
+///
+/// # Parameters
+///
+/// * `interner` - The string interner containing the interned strings
+/// * `key` - Optional intern key to resolve
+///
+/// # Returns
+///
+/// The resolved string, or None if the key was None.
+pub fn resolve_option(interner: &StringInterner, key: Option<InternKey>) -> Option<String> {
+  key.map(|k| interner.resolve(&k).to_string())
+}
+
+/// Interns a slice of strings into a vector of intern keys.
+///
+/// # Parameters
+///
+/// * `interner` - The string interner to use
+/// * `strings` - Slice of strings to intern
+///
+/// # Returns
+///
+/// A vector of intern keys corresponding to the input strings.
+pub fn intern_vec(interner: &mut StringInterner, strings: &[String]) -> Vec<InternKey> {
+  strings
+    .iter()
+    .map(|s| interner.get_or_intern(s.as_str()))
+    .collect()
+}
+
+/// Resolves a slice of intern keys back to a vector of Strings.
+///
+/// # Parameters
+///
+/// * `interner` - The string interner containing the interned strings
+/// * `keys` - Slice of intern keys to resolve
+///
+/// # Returns
+///
+/// A vector of resolved strings.
+pub fn resolve_vec(interner: &StringInterner, keys: &[InternKey]) -> Vec<String> {
+  keys
+    .iter()
+    .map(|k| interner.resolve(k).to_string())
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_intern_option_some() {
+    let mut interner = StringInterner::default();
+    let key = intern_option(&mut interner, Some("test"));
+    assert!(key.is_some());
+    assert_eq!(resolve_option(&interner, key), Some("test".to_string()));
+  }
+
+  #[test]
+  fn test_intern_option_none() {
+    let mut interner = StringInterner::default();
+    let key = intern_option(&mut interner, None);
+    assert!(key.is_none());
+    assert_eq!(resolve_option(&interner, key), None);
+  }
+
+  #[test]
+  fn test_intern_vec() {
+    let mut interner = StringInterner::default();
+    let strings = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+    let keys = intern_vec(&mut interner, &strings);
+    assert_eq!(keys.len(), 3);
+    assert_eq!(resolve_vec(&interner, &keys), strings);
+  }
+
+  #[test]
+  fn test_intern_vec_empty() {
+    let mut interner = StringInterner::default();
+    let strings: Vec<String> = vec![];
+    let keys = intern_vec(&mut interner, &strings);
+    assert!(keys.is_empty());
+    assert!(resolve_vec(&interner, &keys).is_empty());
+  }
+
+  #[test]
+  fn test_deduplication() {
+    let mut interner = StringInterner::default();
+    let key1 = interner.get_or_intern("duplicate");
+    let key2 = interner.get_or_intern("duplicate");
+    assert_eq!(key1, key2);
+    assert_eq!(interner.len(), 1);
+  }
+
+  #[test]
+  fn test_multiple_strings() {
+    let mut interner = StringInterner::default();
+    let key_a = interner.get_or_intern("a");
+    let key_b = interner.get_or_intern("b");
+    let key_a2 = interner.get_or_intern("a");
+
+    assert_eq!(key_a, key_a2);
+    assert_ne!(key_a, key_b);
+    assert_eq!(interner.len(), 2);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,18 @@
+/// API client for fetching and caching the Thunderstore package manifest.
 pub mod api;
+/// Command-line interface definitions and argument parsing.
 pub mod cli;
+/// Application configuration management.
 pub mod config;
+/// Error types and result aliases for the application.
 pub mod error;
+/// String interning utilities for memory-efficient string storage.
+pub mod intern;
+/// Logging configuration and setup.
 pub mod logs;
+/// Manifest file parsing for individual mod packages.
 pub mod manifest;
+/// Package data structures and dependency graph resolution.
 pub mod package;
+/// Zip archive extraction and mod installation utilities.
 pub mod zip;

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -2,6 +2,16 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use crate::config::APP_CONFIG;
 
+/// Initializes the application's logging system.
+///
+/// This function sets up tracing with a filter based on the log_level specified
+/// in the application configuration. The logging output follows the structured
+/// logging format provided by tracing_subscriber.
+///
+/// # Panics
+///
+/// Panics if the global default subscriber has already been set or if subscriber
+/// initialization fails.
 #[cfg(not(tarpaulin_include))]
 pub fn setup_logging() {
   let filter = EnvFilter::new(format!("vmm={}", APP_CONFIG.log_level));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod cli;
 mod config;
 mod error;
+mod intern;
 mod logs;
 mod manifest;
 mod package;
@@ -41,7 +42,7 @@ async fn main() -> AppResult<()> {
         tracing::info!("Building dependency graph for mods");
 
         let dg = DependencyGraph::new(packages);
-        let urls = dg.resolve(&manifest);
+        let urls = dg.resolve_interned(&manifest);
 
         tracing::info!("Done building dependency graph, proceeding to download mods if necessary");
 
@@ -56,13 +57,13 @@ async fn main() -> AppResult<()> {
 
       let search_results: Vec<usize> = (0..manifest.len())
         .filter(|&idx| {
-          if let Some(name) = &manifest.names[idx] {
+          if let Some(name) = manifest.resolve_name_at(idx) {
             if name.to_lowercase().contains(&search_term) {
               return true;
             }
           }
 
-          if let Some(full_name) = &manifest.full_names[idx] {
+          if let Some(full_name) = manifest.resolve_full_name_at(idx) {
             if full_name.to_lowercase().contains(&search_term) {
               return true;
             }
@@ -84,21 +85,29 @@ async fn main() -> AppResult<()> {
         for idx in search_results {
           let version = manifest
             .get_latest_version_at(idx)
-            .and_then(|ver_idx| manifest.versions.version_numbers[ver_idx].clone())
+            .and_then(|ver_idx| {
+              intern::resolve_option(
+                &manifest.interner,
+                manifest.versions.version_numbers[ver_idx],
+              )
+            })
             .unwrap_or_else(|| "Unknown".to_string());
 
           let description = manifest
             .get_latest_version_at(idx)
-            .and_then(|ver_idx| manifest.versions.descriptions[ver_idx].clone())
+            .and_then(|ver_idx| {
+              intern::resolve_option(&manifest.interner, manifest.versions.descriptions[ver_idx])
+            })
             .unwrap_or_default();
 
-          let name = manifest.names[idx]
-            .as_ref()
-            .or(manifest.full_names[idx].as_ref())
-            .map(|s| s.as_str())
-            .unwrap_or("Unknown");
+          let name = manifest
+            .resolve_name_at(idx)
+            .or_else(|| manifest.resolve_full_name_at(idx))
+            .unwrap_or_else(|| "Unknown".to_string());
 
-          let owner = manifest.owners[idx].as_deref().unwrap_or("Unknown");
+          let owner = manifest
+            .resolve_owner_at(idx)
+            .unwrap_or_else(|| "Unknown".to_string());
 
           println!("{}-{} ({})", owner, name, version);
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,20 +3,41 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
+/// Manifest metadata for an individual mod package.
+///
+/// This structure represents the manifest.json file found in mod archives,
+/// containing version information, dependencies, and package metadata.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Manifest {
+  /// The version number of this mod (e.g., "1.2.3").
   pub version_number: String,
+  /// The display name of the mod.
   #[serde(default)]
   pub name: String,
+  /// A description of what the mod does.
   #[serde(default)]
   pub description: String,
+  /// Optional URL to the mod's website or documentation.
   #[serde(default)]
   pub website_url: Option<String>,
+  /// List of dependencies in "Owner-ModName" format.
   #[serde(default)]
   pub dependencies: Vec<String>,
 }
 
 impl Manifest {
+  /// Loads and parses a manifest.json file from disk.
+  ///
+  /// This method reads the file, cleans invisible control characters that may
+  /// cause parsing issues, and deserializes the JSON content.
+  ///
+  /// # Parameters
+  ///
+  /// * `path` - Path to the manifest.json file
+  ///
+  /// # Returns
+  ///
+  /// The parsed manifest, or an error if reading or parsing fails.
   pub fn from_file<P: AsRef<Path>>(path: P) -> AppResult<Self> {
     let manifest_content = fs::read_to_string(&path)
       .map_err(|e| AppError::Manifest(format!("Failed to read manifest file: {}", e)))?;
@@ -27,7 +48,19 @@ impl Manifest {
       .map_err(|e| AppError::Manifest(format!("Failed to parse manifest JSON: {}", e)))
   }
 
-  /// Cleans invisible characters from manifest content while preserving valid non-ASCII characters
+  /// Cleans invisible characters from manifest content while preserving valid non-ASCII characters.
+  ///
+  /// Some manifest files may contain invisible control characters (like zero-width spaces,
+  /// BOM markers, or directional marks) that can cause JSON parsing to fail. This method
+  /// filters out these problematic characters while keeping legitimate Unicode text intact.
+  ///
+  /// # Parameters
+  ///
+  /// * `content` - The raw manifest content string
+  ///
+  /// # Returns
+  ///
+  /// A cleaned string with invisible control characters removed.
   fn clean_manifest_content(content: &str) -> String {
     content
       .chars()
@@ -42,7 +75,19 @@ impl Manifest {
   }
 }
 
-/// Checks if a character is an invisible control character that should be removed
+/// Checks if a character is an invisible control character that should be removed.
+///
+/// This helper function identifies Unicode control characters that are invisible
+/// but can interfere with JSON parsing. These include zero-width spaces, joiners,
+/// directional marks, and other formatting characters.
+///
+/// # Parameters
+///
+/// * `c` - The character to check
+///
+/// # Returns
+///
+/// `true` if the character is an invisible control character, `false` otherwise.
 fn is_invisible_control_char(c: char) -> bool {
   matches!(
     c,

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,3 +1,7 @@
+use crate::intern::{
+  InternKey, StringInterner, intern_option, intern_vec, resolve_option, resolve_vec,
+};
+use lasso::Key;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -46,16 +50,132 @@ pub struct VersionManifest {
   pub file_sizes: Vec<Option<u64>>,
 }
 
+/// Struct-of-Arrays representation of the package manifest with interned strings.
+///
+/// This structure builds upon the PackageManifest format by adding string interning
+/// to further reduce memory usage and improve serialization efficiency. Repeated strings
+/// like author names, categories, and URLs are stored once in the interner and referenced
+/// by integer keys throughout the structure.
+///
+/// String interning is particularly beneficial for the Valheim mod ecosystem where the same
+/// authors maintain multiple packages and common patterns appear frequently in metadata.
+#[derive(Debug, Clone)]
+pub struct InternedPackageManifest {
+  pub interner: StringInterner,
+  pub names: Vec<Option<InternKey>>,
+  pub full_names: Vec<Option<InternKey>>,
+  pub owners: Vec<Option<InternKey>>,
+  pub package_urls: Vec<Option<InternKey>>,
+  pub dates_created: Vec<OffsetDateTime>,
+  pub dates_updated: Vec<OffsetDateTime>,
+  pub uuid4s: Vec<Option<InternKey>>,
+  pub rating_scores: Vec<Option<u32>>,
+  pub is_pinned: Vec<Option<bool>>,
+  pub is_deprecated: Vec<Option<bool>>,
+  pub has_nsfw_content: Vec<Option<bool>>,
+  pub categories: Vec<Vec<InternKey>>,
+  pub version_ranges: Vec<(usize, usize)>,
+  pub versions: InternedVersionManifest,
+}
+
+/// Struct-of-Arrays representation of version data with interned strings.
+///
+/// Separates frequently accessed "hot" data from rarely accessed "cold" metadata
+/// for better cache performance and memory efficiency. String values are stored as
+/// interned keys that reference the parent manifest's string interner.
+#[derive(Debug, Clone)]
+pub struct InternedVersionManifest {
+  pub package_indices: Vec<usize>,
+  pub version_numbers: Vec<Option<InternKey>>,
+  pub download_urls: Vec<Option<InternKey>>,
+  pub dependencies: Vec<Vec<InternKey>>,
+  pub dates_created: Vec<OffsetDateTime>,
+  pub descriptions: Vec<Option<InternKey>>,
+  pub icons: Vec<Option<InternKey>>,
+  pub downloads: Vec<Option<u32>>,
+  pub website_urls: Vec<Option<InternKey>>,
+  pub is_active: Vec<Option<bool>>,
+  pub uuid4s: Vec<Option<InternKey>>,
+  pub file_sizes: Vec<Option<u64>>,
+}
+
+/// Serializable representation of an interned package manifest.
+///
+/// This structure converts the runtime InternedPackageManifest into a format that can be
+/// efficiently serialized and deserialized. The string interner is converted to a simple
+/// vector of strings (the string table), and all interned keys become u32 indices into
+/// this table.
+///
+/// This separation allows for optimal serialization performance while maintaining the
+/// memory efficiency benefits of string interning at runtime.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializableInternedManifest {
+  pub string_table: Vec<String>,
+  pub names: Vec<Option<u32>>,
+  pub full_names: Vec<Option<u32>>,
+  pub owners: Vec<Option<u32>>,
+  pub package_urls: Vec<Option<u32>>,
+  pub dates_created: Vec<OffsetDateTime>,
+  pub dates_updated: Vec<OffsetDateTime>,
+  pub uuid4s: Vec<Option<u32>>,
+  pub rating_scores: Vec<Option<u32>>,
+  pub is_pinned: Vec<Option<bool>>,
+  pub is_deprecated: Vec<Option<bool>>,
+  pub has_nsfw_content: Vec<Option<bool>>,
+  pub categories: Vec<Vec<u32>>,
+  pub version_ranges: Vec<(usize, usize)>,
+  pub versions: SerializableInternedVersionManifest,
+}
+
+/// Serializable representation of interned version data.
+///
+/// Contains version information with string values represented as u32 indices into
+/// the parent manifest's string table. This allows efficient serialization while
+/// maintaining the benefits of string interning.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SerializableInternedVersionManifest {
+  pub package_indices: Vec<usize>,
+  pub version_numbers: Vec<Option<u32>>,
+  pub download_urls: Vec<Option<u32>>,
+  pub dependencies: Vec<Vec<u32>>,
+  pub dates_created: Vec<OffsetDateTime>,
+  pub descriptions: Vec<Option<u32>>,
+  pub icons: Vec<Option<u32>>,
+  pub downloads: Vec<Option<u32>>,
+  pub website_urls: Vec<Option<u32>>,
+  pub is_active: Vec<Option<bool>>,
+  pub uuid4s: Vec<Option<u32>>,
+  pub file_sizes: Vec<Option<u64>>,
+}
+
+#[allow(dead_code)]
 impl PackageManifest {
+  /// Returns the number of packages in the manifest.
+  ///
+  /// # Returns
+  ///
+  /// The total count of packages
   pub fn len(&self) -> usize {
     self.names.len()
   }
 
-  #[allow(dead_code)]
+  /// Returns true if the manifest contains no packages.
+  ///
+  /// # Returns
+  ///
+  /// `true` if empty, `false` otherwise
   pub fn is_empty(&self) -> bool {
     self.names.is_empty()
   }
 
+  /// Validates the internal consistency of the manifest structure.
+  ///
+  /// Checks that all parallel vectors have matching lengths and that version
+  /// ranges are valid.
+  ///
+  /// # Returns
+  ///
+  /// Ok if the manifest is valid, otherwise an error describing the problem.
   pub fn validate(&self) -> Result<(), String> {
     let pkg_count = self.names.len();
 
@@ -264,12 +384,30 @@ impl PackageManifest {
     Ok(())
   }
 
+  /// Retrieves a package by its full name.
+  ///
+  /// # Parameters
+  ///
+  /// * `full_name` - The full name of the package to find
+  ///
+  /// # Returns
+  ///
+  /// The package if found, otherwise None.
   #[allow(dead_code)]
   pub fn get_package_by_full_name(&self, full_name: &str) -> Option<Package> {
     let idx = self.find_index_by_full_name(full_name)?;
     Some(self.get_package_at(idx))
   }
 
+  /// Finds the index of a package by its full name.
+  ///
+  /// # Parameters
+  ///
+  /// * `full_name` - The full name to search for
+  ///
+  /// # Returns
+  ///
+  /// The index of the package if found, otherwise None.
   #[allow(dead_code)]
   pub fn find_index_by_full_name(&self, full_name: &str) -> Option<usize> {
     self
@@ -278,6 +416,18 @@ impl PackageManifest {
       .position(|name| name.as_ref().map(|n| n.as_str()) == Some(full_name))
   }
 
+  /// Reconstructs a Package struct from the manifest data at the given index.
+  ///
+  /// This method gathers all package data and its versions from the SoA structure
+  /// and reconstructs a complete Package object.
+  ///
+  /// # Parameters
+  ///
+  /// * `idx` - The index of the package in the manifest
+  ///
+  /// # Returns
+  ///
+  /// A fully materialized Package struct.
   #[allow(dead_code)]
   pub fn get_package_at(&self, idx: usize) -> Package {
     let (version_start, version_end) = self.version_ranges[idx];
@@ -319,6 +469,17 @@ impl PackageManifest {
     }
   }
 
+  /// Returns the index of the latest version for a package.
+  ///
+  /// The latest version is determined by comparing the date_created field of all versions.
+  ///
+  /// # Parameters
+  ///
+  /// * `idx` - The index of the package in the manifest
+  ///
+  /// # Returns
+  ///
+  /// The index of the latest version, or None if the package has no versions.
   pub fn get_latest_version_at(&self, idx: usize) -> Option<usize> {
     let (ver_start, ver_end) = self.version_ranges[idx];
 
@@ -329,6 +490,13 @@ impl PackageManifest {
     (ver_start..ver_end).max_by_key(|&ver_idx| self.versions.dates_created[ver_idx])
   }
 
+  /// Builds an index mapping full package names to their indices.
+  ///
+  /// This is useful for fast lookups of packages by name.
+  ///
+  /// # Returns
+  ///
+  /// A HashMap mapping full names to package indices.
   pub fn build_name_index(&self) -> HashMap<String, usize> {
     self
       .full_names
@@ -339,7 +507,396 @@ impl PackageManifest {
   }
 }
 
+/// Implementation block for VersionManifest.
+///
+/// Currently empty but reserved for future version-specific methods.
 impl VersionManifest {}
+
+impl InternedPackageManifest {
+  /// Returns the number of packages in the manifest.
+  pub fn len(&self) -> usize {
+    self.names.len()
+  }
+
+  /// Returns true if the manifest contains no packages.
+  #[allow(dead_code)]
+  pub fn is_empty(&self) -> bool {
+    self.names.is_empty()
+  }
+
+  /// Resolves the package name at the given index from the string interner.
+  ///
+  /// # Returns
+  ///
+  /// The resolved string if a name exists at the index, otherwise None.
+  pub fn resolve_name_at(&self, idx: usize) -> Option<String> {
+    resolve_option(&self.interner, self.names[idx])
+  }
+
+  /// Resolves the full package name at the given index from the string interner.
+  ///
+  /// # Returns
+  ///
+  /// The resolved string if a full name exists at the index, otherwise None.
+  pub fn resolve_full_name_at(&self, idx: usize) -> Option<String> {
+    resolve_option(&self.interner, self.full_names[idx])
+  }
+
+  /// Resolves the package owner at the given index from the string interner.
+  ///
+  /// # Returns
+  ///
+  /// The resolved string if an owner exists at the index, otherwise None.
+  pub fn resolve_owner_at(&self, idx: usize) -> Option<String> {
+    resolve_option(&self.interner, self.owners[idx])
+  }
+
+  /// Retrieves a package by its full name.
+  ///
+  /// # Parameters
+  ///
+  /// * `full_name` - The full name of the package to find
+  ///
+  /// # Returns
+  ///
+  /// The package if found, otherwise None.
+  #[allow(dead_code)]
+  pub fn get_package_by_full_name(&self, full_name: &str) -> Option<Package> {
+    let idx = self.find_index_by_full_name(full_name)?;
+    Some(self.get_package_at(idx))
+  }
+
+  /// Finds the index of a package by its full name.
+  ///
+  /// # Parameters
+  ///
+  /// * `full_name` - The full name to search for
+  ///
+  /// # Returns
+  ///
+  /// The index of the package if found, otherwise None.
+  #[allow(dead_code)]
+  pub fn find_index_by_full_name(&self, full_name: &str) -> Option<usize> {
+    self.full_names.iter().position(|key| {
+      key
+        .map(|k| self.interner.resolve(&k) == full_name)
+        .unwrap_or(false)
+    })
+  }
+
+  /// Reconstructs a Package struct from the manifest data at the given index.
+  ///
+  /// This method resolves all interned strings and constructs a complete Package
+  /// with all its versions.
+  ///
+  /// # Parameters
+  ///
+  /// * `idx` - The index of the package in the manifest
+  ///
+  /// # Returns
+  ///
+  /// A fully materialized Package struct.
+  #[allow(dead_code)]
+  pub fn get_package_at(&self, idx: usize) -> Package {
+    let (version_start, version_end) = self.version_ranges[idx];
+    let mut versions = Vec::with_capacity(version_end - version_start);
+
+    for ver_idx in version_start..version_end {
+      versions.push(Version {
+        name: resolve_option(&self.interner, self.names[idx]),
+        full_name: resolve_option(&self.interner, self.full_names[idx]),
+        description: resolve_option(&self.interner, self.versions.descriptions[ver_idx]),
+        icon: resolve_option(&self.interner, self.versions.icons[ver_idx]),
+        version_number: resolve_option(&self.interner, self.versions.version_numbers[ver_idx]),
+        dependencies: resolve_vec(&self.interner, &self.versions.dependencies[ver_idx]),
+        download_url: resolve_option(&self.interner, self.versions.download_urls[ver_idx]),
+        downloads: self.versions.downloads[ver_idx],
+        date_created: self.versions.dates_created[ver_idx],
+        website_url: resolve_option(&self.interner, self.versions.website_urls[ver_idx]),
+        is_active: self.versions.is_active[ver_idx],
+        uuid4: resolve_option(&self.interner, self.versions.uuid4s[ver_idx]),
+        file_size: self.versions.file_sizes[ver_idx],
+      });
+    }
+
+    Package {
+      name: resolve_option(&self.interner, self.names[idx]),
+      full_name: resolve_option(&self.interner, self.full_names[idx]),
+      owner: resolve_option(&self.interner, self.owners[idx]),
+      package_url: resolve_option(&self.interner, self.package_urls[idx]),
+      date_created: self.dates_created[idx],
+      date_updated: self.dates_updated[idx],
+      uuid4: resolve_option(&self.interner, self.uuid4s[idx]),
+      rating_score: self.rating_scores[idx],
+      is_pinned: self.is_pinned[idx],
+      is_deprecated: self.is_deprecated[idx],
+      has_nsfw_content: self.has_nsfw_content[idx],
+      categories: resolve_vec(&self.interner, &self.categories[idx]),
+      versions,
+    }
+  }
+
+  /// Returns the index of the latest version for a package.
+  ///
+  /// The latest version is determined by comparing the date_created field of all versions.
+  ///
+  /// # Parameters
+  ///
+  /// * `idx` - The index of the package in the manifest
+  ///
+  /// # Returns
+  ///
+  /// The index of the latest version, or None if the package has no versions.
+  pub fn get_latest_version_at(&self, idx: usize) -> Option<usize> {
+    let (ver_start, ver_end) = self.version_ranges[idx];
+
+    if ver_start >= ver_end {
+      return None;
+    }
+
+    (ver_start..ver_end).max_by_key(|&ver_idx| self.versions.dates_created[ver_idx])
+  }
+
+  /// Builds an index mapping full package names to their indices.
+  ///
+  /// This is useful for fast lookups of packages by name.
+  ///
+  /// # Returns
+  ///
+  /// A HashMap mapping resolved full names to package indices.
+  pub fn build_name_index(&self) -> HashMap<String, usize> {
+    self
+      .full_names
+      .iter()
+      .enumerate()
+      .filter_map(|(idx, key)| {
+        let name = resolve_option(&self.interner, *key)?;
+        Some((name, idx))
+      })
+      .collect()
+  }
+
+  /// Validates the internal consistency of the manifest structure.
+  ///
+  /// Checks that all parallel vectors have matching lengths and that version
+  /// ranges are valid.
+  ///
+  /// # Returns
+  ///
+  /// Ok if the manifest is valid, otherwise an error describing the problem.
+  pub fn validate(&self) -> Result<(), String> {
+    let pkg_count = self.names.len();
+
+    if self.full_names.len() != pkg_count {
+      return Err(format!(
+        "full_names length {} != {}",
+        self.full_names.len(),
+        pkg_count
+      ));
+    }
+
+    if self.owners.len() != pkg_count {
+      return Err(format!(
+        "owners length {} != {}",
+        self.owners.len(),
+        pkg_count
+      ));
+    }
+
+    if self.package_urls.len() != pkg_count {
+      return Err(format!(
+        "package_urls length {} != {}",
+        self.package_urls.len(),
+        pkg_count
+      ));
+    }
+
+    if self.dates_created.len() != pkg_count {
+      return Err(format!(
+        "dates_created length {} != {}",
+        self.dates_created.len(),
+        pkg_count
+      ));
+    }
+
+    if self.dates_updated.len() != pkg_count {
+      return Err(format!(
+        "dates_updated length {} != {}",
+        self.dates_updated.len(),
+        pkg_count
+      ));
+    }
+
+    if self.uuid4s.len() != pkg_count {
+      return Err(format!(
+        "uuid4s length {} != {}",
+        self.uuid4s.len(),
+        pkg_count
+      ));
+    }
+
+    if self.rating_scores.len() != pkg_count {
+      return Err(format!(
+        "rating_scores length {} != {}",
+        self.rating_scores.len(),
+        pkg_count
+      ));
+    }
+
+    if self.is_pinned.len() != pkg_count {
+      return Err(format!(
+        "is_pinned length {} != {}",
+        self.is_pinned.len(),
+        pkg_count
+      ));
+    }
+
+    if self.is_deprecated.len() != pkg_count {
+      return Err(format!(
+        "is_deprecated length {} != {}",
+        self.is_deprecated.len(),
+        pkg_count
+      ));
+    }
+
+    if self.has_nsfw_content.len() != pkg_count {
+      return Err(format!(
+        "has_nsfw_content length {} != {}",
+        self.has_nsfw_content.len(),
+        pkg_count
+      ));
+    }
+
+    if self.categories.len() != pkg_count {
+      return Err(format!(
+        "categories length {} != {}",
+        self.categories.len(),
+        pkg_count
+      ));
+    }
+
+    if self.version_ranges.len() != pkg_count {
+      return Err(format!(
+        "version_ranges length {} != {}",
+        self.version_ranges.len(),
+        pkg_count
+      ));
+    }
+
+    let version_count = self.versions.package_indices.len();
+
+    if self.versions.version_numbers.len() != version_count {
+      return Err(format!(
+        "versions.version_numbers length {} != {}",
+        self.versions.version_numbers.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.download_urls.len() != version_count {
+      return Err(format!(
+        "versions.download_urls length {} != {}",
+        self.versions.download_urls.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.dependencies.len() != version_count {
+      return Err(format!(
+        "versions.dependencies length {} != {}",
+        self.versions.dependencies.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.dates_created.len() != version_count {
+      return Err(format!(
+        "versions.dates_created length {} != {}",
+        self.versions.dates_created.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.descriptions.len() != version_count {
+      return Err(format!(
+        "versions.descriptions length {} != {}",
+        self.versions.descriptions.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.icons.len() != version_count {
+      return Err(format!(
+        "versions.icons length {} != {}",
+        self.versions.icons.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.downloads.len() != version_count {
+      return Err(format!(
+        "versions.downloads length {} != {}",
+        self.versions.downloads.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.website_urls.len() != version_count {
+      return Err(format!(
+        "versions.website_urls length {} != {}",
+        self.versions.website_urls.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.is_active.len() != version_count {
+      return Err(format!(
+        "versions.is_active length {} != {}",
+        self.versions.is_active.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.uuid4s.len() != version_count {
+      return Err(format!(
+        "versions.uuid4s length {} != {}",
+        self.versions.uuid4s.len(),
+        version_count
+      ));
+    }
+
+    if self.versions.file_sizes.len() != version_count {
+      return Err(format!(
+        "versions.file_sizes length {} != {}",
+        self.versions.file_sizes.len(),
+        version_count
+      ));
+    }
+
+    for (idx, (start, end)) in self.version_ranges.iter().enumerate() {
+      if start > end {
+        return Err(format!(
+          "Invalid version range at package {}: {} > {}",
+          idx, start, end
+        ));
+      }
+
+      if *end > version_count {
+        return Err(format!(
+          "Version range at package {} ends at {} but only {} versions exist",
+          idx, end, version_count
+        ));
+      }
+    }
+
+    Ok(())
+  }
+}
+
+/// Implementation block for InternedVersionManifest.
+///
+/// Currently empty but reserved for future version-specific methods.
+impl InternedVersionManifest {}
 
 /// Represents a mod package from the Thunderstore API.
 ///
@@ -510,6 +1067,7 @@ impl DependencyGraph {
   /// # Returns
   ///
   /// A HashMap where keys are filenames and values are download URLs for all required packages
+  #[allow(dead_code)]
   pub fn resolve(&self, manifest: &PackageManifest) -> HashMap<String, String> {
     let name_index = manifest.build_name_index();
     let mut sorted_set: BTreeSet<&str> = self.install_packages.iter().map(String::as_str).collect();
@@ -558,6 +1116,7 @@ impl DependencyGraph {
   /// # Returns
   ///
   /// A HashMap mapping filenames to download URLs
+  #[allow(dead_code)]
   fn package_indices_to_urls(
     manifest: &PackageManifest,
     indices: &[usize],
@@ -572,6 +1131,93 @@ impl DependencyGraph {
         let zip_name = format!("{}-{}.zip", package_name, version_number);
 
         Some((zip_name, url.clone()))
+      })
+      .collect()
+  }
+
+  /// Resolves all dependencies for the requested packages using an interned manifest.
+  ///
+  /// This method:
+  /// 1. Starts with the user-requested packages
+  /// 2. For each package, adds its dependencies to the list to process
+  /// 3. Continues until all dependencies are resolved
+  ///
+  /// # Parameters
+  ///
+  /// * `manifest` - An InternedPackageManifest of all available packages
+  ///
+  /// # Returns
+  ///
+  /// A HashMap where keys are filenames and values are download URLs for all required packages
+  pub fn resolve_interned(&self, manifest: &InternedPackageManifest) -> HashMap<String, String> {
+    let name_index = manifest.build_name_index();
+    let mut sorted_set: BTreeSet<String> = self.install_packages.iter().cloned().collect();
+    let mut install_indices = Vec::new();
+
+    tracing::debug!("Starting with mod list of: {:#?}", sorted_set);
+
+    while !sorted_set.is_empty() {
+      let Some(item) = sorted_set.pop_first() else {
+        continue;
+      };
+
+      let item = item.split('-').take(2).collect::<Vec<&str>>().join("-");
+      let Some(&pkg_idx) = name_index.get(&item) else {
+        continue;
+      };
+
+      if let Some(latest_ver_idx) = manifest.get_latest_version_at(pkg_idx) {
+        let deps = resolve_vec(
+          &manifest.interner,
+          &manifest.versions.dependencies[latest_ver_idx],
+        );
+
+        for dep in deps {
+          tracing::debug!(
+            "Found dependency of {:#?} for {:#?} mod",
+            dep,
+            manifest.resolve_name_at(pkg_idx).unwrap_or_default(),
+          );
+          sorted_set.insert(dep);
+        }
+      }
+
+      install_indices.push(pkg_idx);
+    }
+
+    Self::package_indices_to_urls_interned(manifest, &install_indices)
+  }
+
+  /// Converts package indices to a HashMap of filenames and download URLs using an interned manifest.
+  ///
+  /// # Parameters
+  ///
+  /// * `manifest` - The InternedPackageManifest
+  /// * `indices` - Vector of package indices
+  ///
+  /// # Returns
+  ///
+  /// A HashMap mapping filenames to download URLs
+  fn package_indices_to_urls_interned(
+    manifest: &InternedPackageManifest,
+    indices: &[usize],
+  ) -> HashMap<String, String> {
+    indices
+      .iter()
+      .filter_map(|&idx| {
+        let latest_ver_idx = manifest.get_latest_version_at(idx)?;
+        let url = resolve_option(
+          &manifest.interner,
+          manifest.versions.download_urls[latest_ver_idx],
+        )?;
+        let version_number = resolve_option(
+          &manifest.interner,
+          manifest.versions.version_numbers[latest_ver_idx],
+        )?;
+        let package_name = manifest.resolve_full_name_at(idx)?;
+        let zip_name = format!("{}-{}.zip", package_name, version_number);
+
+        Some((zip_name, url))
       })
       .collect()
   }
@@ -674,6 +1320,527 @@ impl From<Vec<Package>> for PackageManifest {
         is_active,
         uuid4s: version_uuid4s,
         file_sizes,
+      },
+    }
+  }
+}
+
+impl From<Vec<Package>> for InternedPackageManifest {
+  fn from(packages: Vec<Package>) -> Self {
+    let num_packages = packages.len();
+    let total_versions: usize = packages.iter().map(|p| p.versions.len()).sum();
+
+    let mut interner = StringInterner::default();
+
+    let mut names = Vec::with_capacity(num_packages);
+    let mut full_names = Vec::with_capacity(num_packages);
+    let mut owners = Vec::with_capacity(num_packages);
+    let mut package_urls = Vec::with_capacity(num_packages);
+    let mut dates_created = Vec::with_capacity(num_packages);
+    let mut dates_updated = Vec::with_capacity(num_packages);
+    let mut uuid4s = Vec::with_capacity(num_packages);
+    let mut rating_scores = Vec::with_capacity(num_packages);
+    let mut is_pinned = Vec::with_capacity(num_packages);
+    let mut is_deprecated = Vec::with_capacity(num_packages);
+    let mut has_nsfw_content = Vec::with_capacity(num_packages);
+    let mut categories = Vec::with_capacity(num_packages);
+    let mut version_ranges = Vec::with_capacity(num_packages);
+
+    let mut package_indices = Vec::with_capacity(total_versions);
+    let mut version_numbers = Vec::with_capacity(total_versions);
+    let mut download_urls = Vec::with_capacity(total_versions);
+    let mut dependencies = Vec::with_capacity(total_versions);
+    let mut version_dates_created = Vec::with_capacity(total_versions);
+    let mut descriptions = Vec::with_capacity(total_versions);
+    let mut icons = Vec::with_capacity(total_versions);
+    let mut downloads = Vec::with_capacity(total_versions);
+    let mut website_urls = Vec::with_capacity(total_versions);
+    let mut is_active = Vec::with_capacity(total_versions);
+    let mut version_uuid4s = Vec::with_capacity(total_versions);
+    let mut file_sizes = Vec::with_capacity(total_versions);
+
+    let mut version_offset = 0;
+
+    for (pkg_idx, package) in packages.into_iter().enumerate() {
+      names.push(intern_option(&mut interner, package.name.as_deref()));
+      full_names.push(intern_option(&mut interner, package.full_name.as_deref()));
+      owners.push(intern_option(&mut interner, package.owner.as_deref()));
+      package_urls.push(intern_option(&mut interner, package.package_url.as_deref()));
+      dates_created.push(package.date_created);
+      dates_updated.push(package.date_updated);
+      uuid4s.push(intern_option(&mut interner, package.uuid4.as_deref()));
+      rating_scores.push(package.rating_score);
+      is_pinned.push(package.is_pinned);
+      is_deprecated.push(package.is_deprecated);
+      has_nsfw_content.push(package.has_nsfw_content);
+      categories.push(intern_vec(&mut interner, &package.categories));
+
+      let version_count = package.versions.len();
+      version_ranges.push((version_offset, version_offset + version_count));
+
+      for version in package.versions {
+        package_indices.push(pkg_idx);
+        version_numbers.push(intern_option(
+          &mut interner,
+          version.version_number.as_deref(),
+        ));
+        download_urls.push(intern_option(
+          &mut interner,
+          version.download_url.as_deref(),
+        ));
+        dependencies.push(intern_vec(&mut interner, &version.dependencies));
+        version_dates_created.push(version.date_created);
+        descriptions.push(intern_option(&mut interner, version.description.as_deref()));
+        icons.push(intern_option(&mut interner, version.icon.as_deref()));
+        downloads.push(version.downloads);
+        website_urls.push(intern_option(&mut interner, version.website_url.as_deref()));
+        is_active.push(version.is_active);
+        version_uuid4s.push(intern_option(&mut interner, version.uuid4.as_deref()));
+        file_sizes.push(version.file_size);
+      }
+
+      version_offset += version_count;
+    }
+
+    InternedPackageManifest {
+      interner,
+      names,
+      full_names,
+      owners,
+      package_urls,
+      dates_created,
+      dates_updated,
+      uuid4s,
+      rating_scores,
+      is_pinned,
+      is_deprecated,
+      has_nsfw_content,
+      categories,
+      version_ranges,
+      versions: InternedVersionManifest {
+        package_indices,
+        version_numbers,
+        download_urls,
+        dependencies,
+        dates_created: version_dates_created,
+        descriptions,
+        icons,
+        downloads,
+        website_urls,
+        is_active,
+        uuid4s: version_uuid4s,
+        file_sizes,
+      },
+    }
+  }
+}
+
+impl From<PackageManifest> for InternedPackageManifest {
+  fn from(manifest: PackageManifest) -> Self {
+    let mut interner = StringInterner::default();
+
+    let names: Vec<Option<InternKey>> = manifest
+      .names
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let full_names: Vec<Option<InternKey>> = manifest
+      .full_names
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let owners: Vec<Option<InternKey>> = manifest
+      .owners
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let package_urls: Vec<Option<InternKey>> = manifest
+      .package_urls
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let uuid4s: Vec<Option<InternKey>> = manifest
+      .uuid4s
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let categories: Vec<Vec<InternKey>> = manifest
+      .categories
+      .iter()
+      .map(|c| intern_vec(&mut interner, c))
+      .collect();
+
+    let version_numbers: Vec<Option<InternKey>> = manifest
+      .versions
+      .version_numbers
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let download_urls: Vec<Option<InternKey>> = manifest
+      .versions
+      .download_urls
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let dependencies: Vec<Vec<InternKey>> = manifest
+      .versions
+      .dependencies
+      .iter()
+      .map(|d| intern_vec(&mut interner, d))
+      .collect();
+
+    let descriptions: Vec<Option<InternKey>> = manifest
+      .versions
+      .descriptions
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let icons: Vec<Option<InternKey>> = manifest
+      .versions
+      .icons
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let website_urls: Vec<Option<InternKey>> = manifest
+      .versions
+      .website_urls
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    let version_uuid4s: Vec<Option<InternKey>> = manifest
+      .versions
+      .uuid4s
+      .iter()
+      .map(|s| intern_option(&mut interner, s.as_deref()))
+      .collect();
+
+    InternedPackageManifest {
+      interner,
+      names,
+      full_names,
+      owners,
+      package_urls,
+      dates_created: manifest.dates_created,
+      dates_updated: manifest.dates_updated,
+      uuid4s,
+      rating_scores: manifest.rating_scores,
+      is_pinned: manifest.is_pinned,
+      is_deprecated: manifest.is_deprecated,
+      has_nsfw_content: manifest.has_nsfw_content,
+      categories,
+      version_ranges: manifest.version_ranges,
+      versions: InternedVersionManifest {
+        package_indices: manifest.versions.package_indices,
+        version_numbers,
+        download_urls,
+        dependencies,
+        dates_created: manifest.versions.dates_created,
+        descriptions,
+        icons,
+        downloads: manifest.versions.downloads,
+        website_urls,
+        is_active: manifest.versions.is_active,
+        uuid4s: version_uuid4s,
+        file_sizes: manifest.versions.file_sizes,
+      },
+    }
+  }
+}
+
+/// Converts an InternKey to its u32 index representation for serialization.
+///
+/// # Parameters
+///
+/// * `_interner` - The StringInterner (unused but kept for API symmetry)
+/// * `key` - The InternKey to convert
+///
+/// # Returns
+///
+/// The u32 index corresponding to the key
+fn key_to_index(_interner: &StringInterner, key: InternKey) -> u32 {
+  key.into_usize() as u32
+}
+
+/// Converts a u32 index back to an InternKey for deserialization.
+///
+/// # Parameters
+///
+/// * `index` - The u32 index to convert
+///
+/// # Returns
+///
+/// The InternKey corresponding to the index
+///
+/// # Panics
+///
+/// Panics if the index cannot be converted to a valid InternKey
+fn index_to_key(index: u32) -> InternKey {
+  InternKey::try_from_usize(index as usize).expect("Invalid intern key index")
+}
+
+impl From<&InternedPackageManifest> for SerializableInternedManifest {
+  fn from(manifest: &InternedPackageManifest) -> Self {
+    let string_table: Vec<String> = manifest.interner.strings().map(|s| s.to_string()).collect();
+
+    let names: Vec<Option<u32>> = manifest
+      .names
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let full_names: Vec<Option<u32>> = manifest
+      .full_names
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let owners: Vec<Option<u32>> = manifest
+      .owners
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let package_urls: Vec<Option<u32>> = manifest
+      .package_urls
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let uuid4s: Vec<Option<u32>> = manifest
+      .uuid4s
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let categories: Vec<Vec<u32>> = manifest
+      .categories
+      .iter()
+      .map(|keys| {
+        keys
+          .iter()
+          .map(|k| key_to_index(&manifest.interner, *k))
+          .collect()
+      })
+      .collect();
+
+    let version_numbers: Vec<Option<u32>> = manifest
+      .versions
+      .version_numbers
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let download_urls: Vec<Option<u32>> = manifest
+      .versions
+      .download_urls
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let dependencies: Vec<Vec<u32>> = manifest
+      .versions
+      .dependencies
+      .iter()
+      .map(|keys| {
+        keys
+          .iter()
+          .map(|k| key_to_index(&manifest.interner, *k))
+          .collect()
+      })
+      .collect();
+
+    let descriptions: Vec<Option<u32>> = manifest
+      .versions
+      .descriptions
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let icons: Vec<Option<u32>> = manifest
+      .versions
+      .icons
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let website_urls: Vec<Option<u32>> = manifest
+      .versions
+      .website_urls
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    let version_uuid4s: Vec<Option<u32>> = manifest
+      .versions
+      .uuid4s
+      .iter()
+      .map(|k| k.map(|key| key_to_index(&manifest.interner, key)))
+      .collect();
+
+    SerializableInternedManifest {
+      string_table,
+      names,
+      full_names,
+      owners,
+      package_urls,
+      dates_created: manifest.dates_created.clone(),
+      dates_updated: manifest.dates_updated.clone(),
+      uuid4s,
+      rating_scores: manifest.rating_scores.clone(),
+      is_pinned: manifest.is_pinned.clone(),
+      is_deprecated: manifest.is_deprecated.clone(),
+      has_nsfw_content: manifest.has_nsfw_content.clone(),
+      categories,
+      version_ranges: manifest.version_ranges.clone(),
+      versions: SerializableInternedVersionManifest {
+        package_indices: manifest.versions.package_indices.clone(),
+        version_numbers,
+        download_urls,
+        dependencies,
+        dates_created: manifest.versions.dates_created.clone(),
+        descriptions,
+        icons,
+        downloads: manifest.versions.downloads.clone(),
+        website_urls,
+        is_active: manifest.versions.is_active.clone(),
+        uuid4s: version_uuid4s,
+        file_sizes: manifest.versions.file_sizes.clone(),
+      },
+    }
+  }
+}
+
+impl From<SerializableInternedManifest> for InternedPackageManifest {
+  fn from(manifest: SerializableInternedManifest) -> Self {
+    let mut interner = StringInterner::default();
+
+    for s in &manifest.string_table {
+      interner.get_or_intern(s);
+    }
+
+    let names: Vec<Option<InternKey>> = manifest
+      .names
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let full_names: Vec<Option<InternKey>> = manifest
+      .full_names
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let owners: Vec<Option<InternKey>> = manifest
+      .owners
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let package_urls: Vec<Option<InternKey>> = manifest
+      .package_urls
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let uuid4s: Vec<Option<InternKey>> = manifest
+      .uuid4s
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let categories: Vec<Vec<InternKey>> = manifest
+      .categories
+      .iter()
+      .map(|indices| indices.iter().map(|&i| index_to_key(i)).collect())
+      .collect();
+
+    let version_numbers: Vec<Option<InternKey>> = manifest
+      .versions
+      .version_numbers
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let download_urls: Vec<Option<InternKey>> = manifest
+      .versions
+      .download_urls
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let dependencies: Vec<Vec<InternKey>> = manifest
+      .versions
+      .dependencies
+      .iter()
+      .map(|indices| indices.iter().map(|&i| index_to_key(i)).collect())
+      .collect();
+
+    let descriptions: Vec<Option<InternKey>> = manifest
+      .versions
+      .descriptions
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let icons: Vec<Option<InternKey>> = manifest
+      .versions
+      .icons
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let website_urls: Vec<Option<InternKey>> = manifest
+      .versions
+      .website_urls
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    let version_uuid4s: Vec<Option<InternKey>> = manifest
+      .versions
+      .uuid4s
+      .iter()
+      .map(|idx| idx.map(index_to_key))
+      .collect();
+
+    InternedPackageManifest {
+      interner,
+      names,
+      full_names,
+      owners,
+      package_urls,
+      dates_created: manifest.dates_created,
+      dates_updated: manifest.dates_updated,
+      uuid4s,
+      rating_scores: manifest.rating_scores,
+      is_pinned: manifest.is_pinned,
+      is_deprecated: manifest.is_deprecated,
+      has_nsfw_content: manifest.has_nsfw_content,
+      categories,
+      version_ranges: manifest.version_ranges,
+      versions: InternedVersionManifest {
+        package_indices: manifest.versions.package_indices,
+        version_numbers,
+        download_urls,
+        dependencies,
+        dates_created: manifest.versions.dates_created,
+        descriptions,
+        icons,
+        downloads: manifest.versions.downloads,
+        website_urls,
+        is_active: manifest.versions.is_active,
+        uuid4s: version_uuid4s,
+        file_sizes: manifest.versions.file_sizes,
       },
     }
   }
@@ -1277,11 +2444,7 @@ mod tests {
 
     let result = manifest.validate();
     assert!(result.is_err());
-    assert!(
-      result
-        .unwrap_err()
-        .contains("versions.dependencies length")
-    );
+    assert!(result.unwrap_err().contains("versions.dependencies length"));
   }
 
   #[test]
@@ -1311,11 +2474,7 @@ mod tests {
 
     let result = manifest.validate();
     assert!(result.is_err());
-    assert!(
-      result
-        .unwrap_err()
-        .contains("versions.descriptions length")
-    );
+    assert!(result.unwrap_err().contains("versions.descriptions length"));
   }
 
   #[test]
@@ -1354,11 +2513,7 @@ mod tests {
 
     let result = manifest.validate();
     assert!(result.is_err());
-    assert!(
-      result
-        .unwrap_err()
-        .contains("versions.website_urls length")
-    );
+    assert!(result.unwrap_err().contains("versions.website_urls length"));
   }
 
   #[test]
@@ -1443,6 +2598,656 @@ mod tests {
     let result = dg.resolve(&manifest);
 
     assert_eq!(result.len(), 1);
+    assert!(result.contains_key("Owner1-ModA-1.0.0.zip"));
+  }
+
+  #[test]
+  fn test_interned_manifest_basic_operations() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let interned: InternedPackageManifest = packages.into();
+
+    assert_eq!(interned.len(), 1);
+
+    assert!(!interned.is_empty());
+
+    assert_eq!(interned.resolve_name_at(0), Some("TestMod".to_string()));
+
+    assert_eq!(
+      interned.resolve_full_name_at(0),
+      Some("TestOwner-TestMod".to_string())
+    );
+
+    assert_eq!(interned.resolve_owner_at(0), Some("TestOwner".to_string()));
+  }
+
+  #[test]
+  fn test_interned_manifest_get_package_by_full_name() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let interned: InternedPackageManifest = packages.into();
+
+    let found = interned.get_package_by_full_name("TestOwner-TestMod");
+
+    assert!(found.is_some());
+
+    let package = found.unwrap();
+
+    assert_eq!(package.name, Some("TestMod".to_string()));
+
+    assert_eq!(package.owner, Some("TestOwner".to_string()));
+
+    assert_eq!(package.versions.len(), 1);
+  }
+
+  #[test]
+  fn test_interned_manifest_find_index_by_full_name() {
+    let pkg1 = create_test_package("ModA", "Owner1", "1.0.0");
+    let pkg2 = create_test_package("ModB", "Owner2", "2.0.0");
+    let packages = vec![pkg1, pkg2];
+    let interned: InternedPackageManifest = packages.into();
+
+    assert_eq!(interned.find_index_by_full_name("Owner1-ModA"), Some(0));
+
+    assert_eq!(interned.find_index_by_full_name("Owner2-ModB"), Some(1));
+
+    assert_eq!(interned.find_index_by_full_name("NonExistent"), None);
+  }
+
+  #[test]
+  fn test_interned_manifest_get_package_at() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let interned: InternedPackageManifest = packages.into();
+
+    let package = interned.get_package_at(0);
+
+    assert_eq!(package.name, Some("TestMod".to_string()));
+
+    assert_eq!(package.full_name, Some("TestOwner-TestMod".to_string()));
+
+    assert_eq!(package.owner, Some("TestOwner".to_string()));
+
+    assert_eq!(package.versions.len(), 1);
+
+    assert_eq!(
+      package.versions[0].version_number,
+      Some("1.0.0".to_string())
+    );
+  }
+
+  #[test]
+  fn test_interned_manifest_get_latest_version_at() {
+    let mut pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+
+    let older_version = Version {
+      name: Some("TestMod".to_string()),
+      full_name: Some("TestOwner-TestMod".to_string()),
+      description: Some("Older version".to_string()),
+      icon: Some("icon.png".to_string()),
+      version_number: Some("0.9.0".to_string()),
+      dependencies: vec![],
+      download_url: Some("https://example.com/TestMod/download-old".to_string()),
+      downloads: Some(50),
+      date_created: OffsetDateTime::now_utc().saturating_sub(time::Duration::days(30)),
+      website_url: Some("https://example.com".to_string()),
+      is_active: Some(true),
+      uuid4: Some("old-version-uuid".to_string()),
+      file_size: Some(512),
+    };
+    pkg.versions.insert(0, older_version);
+
+    let packages = vec![pkg];
+    let interned: InternedPackageManifest = packages.into();
+
+    let latest_idx = interned.get_latest_version_at(0);
+
+    assert!(latest_idx.is_some());
+
+    let version_idx = latest_idx.unwrap();
+    let version_number = interned.versions.version_numbers[version_idx]
+      .map(|key| interned.interner.resolve(&key).to_string());
+
+    assert_eq!(version_number, Some("1.0.0".to_string()));
+  }
+
+  #[test]
+  fn test_interned_manifest_get_latest_version_at_empty_range() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.version_ranges[0] = (0, 0);
+
+    let latest = interned.get_latest_version_at(0);
+
+    assert!(latest.is_none());
+  }
+
+  #[test]
+  fn test_interned_manifest_build_name_index() {
+    let pkg1 = create_test_package("ModA", "Owner1", "1.0.0");
+    let pkg2 = create_test_package("ModB", "Owner2", "2.0.0");
+    let packages = vec![pkg1, pkg2];
+    let interned: InternedPackageManifest = packages.into();
+
+    let index = interned.build_name_index();
+
+    assert_eq!(index.len(), 2);
+
+    assert_eq!(index.get("Owner1-ModA"), Some(&0));
+
+    assert_eq!(index.get("Owner2-ModB"), Some(&1));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_valid() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let interned: InternedPackageManifest = packages.into();
+
+    let result = interned.validate();
+
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_full_names_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.full_names.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("full_names length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_owners_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.owners.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("owners length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_package_urls_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.package_urls.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("package_urls length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_dates_created_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.dates_created.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("dates_created length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_dates_updated_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.dates_updated.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("dates_updated length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_uuid4s_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.uuid4s.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("uuid4s length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_rating_scores_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.rating_scores.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("rating_scores length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_is_pinned_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.is_pinned.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("is_pinned length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_is_deprecated_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.is_deprecated.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("is_deprecated length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_has_nsfw_content_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.has_nsfw_content.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("has_nsfw_content length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_categories_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.categories.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("categories length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_ranges_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.version_ranges.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("version_ranges length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_numbers_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.version_numbers.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("version_numbers length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_download_urls_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.download_urls.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("download_urls length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_dependencies_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.dependencies.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("dependencies length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_dates_created_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.dates_created.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("dates_created length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_descriptions_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.descriptions.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("descriptions length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_icons_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.icons.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("icons length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_downloads_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.downloads.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("downloads length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_website_urls_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.website_urls.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("website_urls length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_is_active_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.is_active.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("is_active length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_uuid4s_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.uuid4s.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("uuid4s length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_mismatched_version_file_sizes_length() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.versions.file_sizes.pop();
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("file_sizes length"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_invalid_version_range() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.version_ranges[0] = (5, 3);
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("Invalid version range"));
+  }
+
+  #[test]
+  fn test_interned_manifest_validate_version_range_out_of_bounds() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let mut interned: InternedPackageManifest = packages.into();
+
+    interned.version_ranges[0] = (0, 999);
+
+    let result = interned.validate();
+
+    assert!(result.is_err());
+
+    assert!(result.unwrap_err().contains("ends at"));
+  }
+
+  #[test]
+  fn test_interned_manifest_serialization_round_trip() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg.clone()];
+    let interned: InternedPackageManifest = packages.into();
+
+    let serializable: SerializableInternedManifest = (&interned).into();
+
+    let binary = bincode::serialize(&serializable).unwrap();
+
+    let deserialized: SerializableInternedManifest = bincode::deserialize(&binary).unwrap();
+
+    let recovered: InternedPackageManifest = deserialized.into();
+
+    assert_eq!(recovered.len(), 1);
+
+    assert_eq!(recovered.resolve_name_at(0), Some("TestMod".to_string()));
+
+    assert_eq!(
+      recovered.resolve_full_name_at(0),
+      Some("TestOwner-TestMod".to_string())
+    );
+
+    let recovered_pkg = recovered.get_package_at(0);
+
+    assert_eq!(recovered_pkg.name, pkg.name);
+
+    assert_eq!(recovered_pkg.full_name, pkg.full_name);
+
+    assert_eq!(recovered_pkg.versions.len(), pkg.versions.len());
+  }
+
+  #[test]
+  fn test_interned_manifest_conversion_from_package_manifest() {
+    let pkg = create_test_package("TestMod", "TestOwner", "1.0.0");
+    let packages = vec![pkg];
+    let v2_manifest: PackageManifest = packages.into();
+
+    let interned: InternedPackageManifest = v2_manifest.clone().into();
+
+    assert_eq!(interned.len(), v2_manifest.len());
+
+    assert_eq!(interned.resolve_name_at(0), v2_manifest.names[0].clone());
+
+    assert_eq!(
+      interned.resolve_full_name_at(0),
+      v2_manifest.full_names[0].clone()
+    );
+  }
+
+  #[test]
+  fn test_interned_manifest_dependency_graph_resolve() {
+    let pkg1 = create_test_package("ModA", "Owner1", "1.0.0");
+    let pkg2 = create_test_package_with_dependencies(
+      "ModB",
+      "Owner2",
+      "2.0.0",
+      vec!["Owner3-ModC".to_string()],
+    );
+    let pkg3 = create_test_package_with_dependencies(
+      "ModC",
+      "Owner3",
+      "1.5.0",
+      vec!["Owner4-ModD".to_string()],
+    );
+    let pkg4 = create_test_package("ModD", "Owner4", "0.9.0");
+
+    let packages = vec![pkg1, pkg2, pkg3, pkg4];
+    let interned: InternedPackageManifest = packages.into();
+
+    let dg1 = DependencyGraph::new(vec!["Owner1-ModA".to_string()]);
+    let result1 = dg1.resolve_interned(&interned);
+
+    assert_eq!(result1.len(), 1);
+
+    assert!(result1.contains_key("Owner1-ModA-1.0.0.zip"));
+
+    let dg2 = DependencyGraph::new(vec!["Owner2-ModB".to_string()]);
+    let result2 = dg2.resolve_interned(&interned);
+
+    assert_eq!(result2.len(), 3);
+
+    assert!(result2.contains_key("Owner2-ModB-2.0.0.zip"));
+
+    assert!(result2.contains_key("Owner3-ModC-1.5.0.zip"));
+
+    assert!(result2.contains_key("Owner4-ModD-0.9.0.zip"));
+  }
+
+  #[test]
+  fn test_interned_manifest_dependency_graph_resolve_with_missing_dependency() {
+    let pkg1 = create_test_package("ModA", "Owner1", "1.0.0");
+    let pkg2 = create_test_package_with_dependencies(
+      "ModB",
+      "Owner2",
+      "2.0.0",
+      vec!["Owner3-NonExistent".to_string()],
+    );
+
+    let packages = vec![pkg1, pkg2];
+    let interned: InternedPackageManifest = packages.into();
+
+    let dg = DependencyGraph::new(vec!["Owner2-ModB".to_string()]);
+    let result = dg.resolve_interned(&interned);
+
+    assert_eq!(result.len(), 1);
+
+    assert!(result.contains_key("Owner2-ModB-2.0.0.zip"));
+  }
+
+  #[test]
+  fn test_interned_manifest_dependency_graph_resolve_with_version_suffix() {
+    let pkg1 = create_test_package("ModA", "Owner1", "1.0.0");
+
+    let packages = vec![pkg1];
+    let interned: InternedPackageManifest = packages.into();
+
+    let dg = DependencyGraph::new(vec!["Owner1-ModA-1.0.0".to_string()]);
+    let result = dg.resolve_interned(&interned);
+
+    assert_eq!(result.len(), 1);
+
     assert!(result.contains_key("Owner1-ModA-1.0.0.zip"));
   }
 }


### PR DESCRIPTION
Reduce memory usage and improve serialization efficiency by
deduplicating repeated strings across package data. The manifest
contains thousands of packages with highly repetitive data like author
names, categories, and version numbers. String interning allows these
values to be stored once and referenced by key, significantly reducing
both memory footprint and serialized size.

This optimization is particularly beneficial for the Valheim mod
ecosystem where the same authors maintain multiple packages and common
patterns appear frequently in package metadata.
